### PR TITLE
style: modernize frontend UI typography and layout

### DIFF
--- a/bin/coordinator-frontend/public/media/home/grid_overview.svg
+++ b/bin/coordinator-frontend/public/media/home/grid_overview.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#FF5500" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="7" height="7" rx="1"/>
+  <rect x="14" y="3" width="7" height="7" rx="1"/>
+  <rect x="3" y="14" width="7" height="7" rx="1"/>
+  <rect x="14" y="14" width="7" height="7" rx="1"/>
+</svg>

--- a/bin/coordinator-frontend/public/media/index.ts
+++ b/bin/coordinator-frontend/public/media/index.ts
@@ -5,6 +5,7 @@ import transactionsIcon from "./Sidebar/transactionsIcon.svg"
 import assetsIcon from "./Sidebar/assetsIcon.svg"
 import assetValIcon from "./home/circum_dollar.svg"
 import actionIcon from "./home/fluent_sparkle-action-24-regular.svg"
+import gridOverviewIcon from "./home/grid_overview.svg"
 import sendIcon from "./pendingActions/Vector (2).svg"
 import redSquareIcon from "./pendingActions/Rectangle 24.svg"
 import peopleIcon from "./pendingActions/material-symbols-light_group-outline.svg"
@@ -20,6 +21,6 @@ import arrow from "./interactions/lets-icons_line-out.svg"
 import tokenIcon from "./assets/Rectangle 25.svg"
 import userIcon from "./pendingActions/Vector (4).svg"
 import receiveIcon from "./Vector (5).svg"
-const media = { greyBox, HomeIcon, settingsIcon, transactionsIcon, assetsIcon, assetValIcon, actionIcon, sendIcon, redSquareIcon, peopleIcon, sentDash, totalTransactionsIcon, thisMonthIcon, searchIcon, signer1, signer2, signer3, warningIcon, arrow, tokenIcon, userIcon, receiveIcon }
+const media = { greyBox, HomeIcon, settingsIcon, transactionsIcon, assetsIcon, assetValIcon, actionIcon, gridOverviewIcon, sendIcon, redSquareIcon, peopleIcon, sentDash, totalTransactionsIcon, thisMonthIcon, searchIcon, signer1, signer2, signer3, warningIcon, arrow, tokenIcon, userIcon, receiveIcon }
 
 export default media

--- a/bin/coordinator-frontend/src/app/dashboard/assets/components/TokenHoldings.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/assets/components/TokenHoldings.tsx
@@ -20,11 +20,11 @@ const TokenHoldings = ({ fungibleAssets, isLoading }: TokenHoldingsProps) => {
   };
 
   return (
-    <div className="flex flex-col gap-2 border-[0.5px] border-[#00000033] p-4 font-dmmono w-full">
+    <div className="flex flex-col gap-2 border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 font-geist w-full">
       {/* Header */}
       <div className="flex justify-between items-center">
-        <div className="#00000099 font-[500] text-[#00000099] text-[16px]">
-          TOKEN HOLDINGS
+        <div className="font-[500] text-[#00000099] text-[16px]">
+          Token Holdings
         </div>
       </div>
 
@@ -34,16 +34,16 @@ const TokenHoldings = ({ fungibleAssets, isLoading }: TokenHoldingsProps) => {
           <div className="flex items-center justify-center py-8">
             <div className="flex items-center space-x-2">
               <div className="w-4 h-4 border-2 border-[#FF5500] border-t-transparent rounded-full animate-spin"></div>
-              <span className="text-black font-dmmono text-[12px]">Loading tokens...</span>
+              <span className="text-black font-geist text-[12px]">Loading tokens...</span>
             </div>
           </div>
         ) : fungibleAssets.length === 0 ? (
           <div className="flex items-center justify-center py-8">
-            <span className="text-gray-500 font-dmmono text-[12px]">No tokens available</span>
+            <span className="text-gray-500 font-geist text-[12px]">No tokens available</span>
           </div>
         ) : (
           fungibleAssets.map((asset, index) => (
-            <div key={index} className="bg-white border border-gray-200 py-3 px-4 flex items-center justify-between">
+            <div key={index} className="bg-white border border-[rgba(0,0,0,0.08)] rounded-[8px] py-3 px-4 flex items-center justify-between">
               {/* Left Side - Token Info */}
               <div className="flex items-center space-x-3">
                 {/* Token Icon */}
@@ -55,12 +55,12 @@ const TokenHoldings = ({ fungibleAssets, isLoading }: TokenHoldingsProps) => {
                 />
 
                 {/* Token Details */}
-                <div className="flex flex-col font-dmmono">
+                <div className="flex flex-col font-geist">
                   <div className="flex gap-2 items-center">
-                    <div className="font-[500] text-[12px] text-black uppercase">
+                    <div className="font-[500] text-[12px] text-black">
                       MID{index + 1}
                     </div>
-                    <div className="text-[8px] text-[#0000007D] font-bold font-dmmono">Miden Token</div>
+                    <div className="text-[8px] text-[#0000007D] font-bold font-geist">Miden Token</div>
                   </div>
 
                   <div className="flex items-center gap-2">
@@ -88,8 +88,8 @@ const TokenHoldings = ({ fungibleAssets, isLoading }: TokenHoldingsProps) => {
 
               {/* Right Side - Values */}
               <div className="flex flex-col items-end">
-                <div className="text-[12px] font-bold text-[#000000] font-dmmono">{asset.balance/1000000}</div>
-                <div className="text-[8px] text-[#000000] font-dmmono">{asset.balance/1000000} USD</div>
+                <div className="text-[12px] font-bold text-[#000000] font-geist">{asset.balance/1000000}</div>
+                <div className="text-[8px] text-[#000000] font-geist">{asset.balance/1000000} USD</div>
               </div>
             </div>
           ))

--- a/bin/coordinator-frontend/src/app/dashboard/assets/page.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/assets/page.tsx
@@ -40,95 +40,102 @@ const Assets = () => {
 
   return (
     <>
-      <div className="flex flex-col p-2 w-[calc(100vw-150px)] font-dmmono">
+      <div className="flex flex-col p-4 w-full font-geist">
         {/*Heading*/}
-        <div className="p-2">
-          <div className="text-[#000000] text-[24px] font-bold font-dmmono">
-            ASSETS
+        <div className="mb-4">
+          <div className="text-[#111] text-[22px] md:text-[24px] font-[600] font-geist">
+            Assets
           </div>
-          <div className="text-[16px] text-[#0000007A] font-dmmono font-bold">
-            Manage your digital assets and NFTS
+          <div className="text-[13px] md:text-[14px] text-[rgba(0,0,0,0.5)] font-geist font-[400] mt-1">
+            Manage your digital assets and NFTs
           </div>
         </div>
         {/*Top Cards Div*/}
-        <div className="grid grid-cols-12 gap-10 p-2">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 md:gap-6">
           {/*Total Asset Value Div*/}
-          <div className="col-span-4 flex flex-col justify-between h-[135px] border-[0.5px] border-[#00000033] p-3">
-            <div className="flex items-left space-x-2 font-dmmono text-black">
-              <Image
-                src={media.totalTransactionsIcon}
-                alt="totalTransactionsIcon"
-                quality={100}
-              />
-              <div className="font-dmmono text-[16px] text-[#000000] font-[500]">
-                TOTAL ASSET VALUE
+          <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+            <div className="flex items-center gap-2.5">
+              <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+                <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                  <circle cx="12" cy="12" r="9"/>
+                  <path d="M14.5 9a2.5 2.5 0 0 0-2.5-2h-1a2 2 0 0 0 0 4h2a2 2 0 0 1 0 4h-1a2.5 2.5 0 0 1-2.5-2"/>
+                  <line x1="12" y1="6" x2="12" y2="7"/>
+                  <line x1="12" y1="17" x2="12" y2="18"/>
+                </svg>
+              </div>
+              <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
+                Total Asset Value
               </div>
             </div>
-            <div>
-              <div className=" text-[24px] font-[500] font-dmmono text-[#000000]">
+            <div className="flex flex-col gap-1 mt-auto">
+              <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
                 {totalBalance.toFixed(2)}
               </div>
-              <div className="text-sm text-gray-700">{vaultBalances.length} token(s)</div>
-            </div>
-          </div>
-          {/*This Month Div*/}
-          <div className="col-span-4 flex flex-col justify-between h-[135px] border-[0.5px] border-[#00000033] p-3">
-            <div className="flex items-left space-x-2 font-dmmono text-black">
-              <Image
-                src={media.thisMonthIcon}
-                alt="thisMonthIcon"
-                quality={100}
-              />
-              <div className="font-dmmono text-[16px] text-[#000000] font-[500]">
-                NUMBER OF TOKENS HELD
+              <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+                {vaultBalances.length} token(s)
               </div>
             </div>
-            <div>
-              <div className=" text-[24px] font-[500] font-dmmono text-[#000000]">
+          </div>
+          {/*Number of Tokens Held Div*/}
+          <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+            <div className="flex items-center gap-2.5">
+              <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+                <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                  <ellipse cx="12" cy="6" rx="8" ry="3"/>
+                  <path d="M4 6v6c0 1.66 3.58 3 8 3s8-1.34 8-3V6"/>
+                  <path d="M4 12v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6"/>
+                </svg>
+              </div>
+              <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
+                Tokens Held
+              </div>
+            </div>
+            <div className="flex flex-col gap-1 mt-auto">
+              <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
                 {vaultBalances.length}
               </div>
-              <div className="text-sm text-gray-700">Total</div>
+              <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+                Total
+              </div>
             </div>
           </div>
-          {/*Success Rate Div*/}
-          <div className="col-span-4 flex flex-col justify-between h-[135px] border-[0.5px] border-[#00000033] p-3">
-            <div className="flex items-left space-x-2 font-dmmono text-black">
-              <Image
-                src={media.assetValIcon}
-                alt="assetValIcon"
-                quality={100}
-              />
-              <div className="font-dmmono text-[16px] text-[#000000] font-[500]">
+          {/*Token Distribution Div*/}
+          <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+            <div className="flex items-center gap-2.5">
+              <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+                <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                  <path d="M21.21 15.89A10 10 0 1 1 8 2.83"/>
+                  <path d="M22 12A10 10 0 0 0 12 2v10z"/>
+                </svg>
+              </div>
+              <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
                 Token Distribution
               </div>
             </div>
-            <div>
-              <div className="text-sm text-gray-700">
-                <div className="flex items-center space-x-8">
-                  {fungibleAssetsWithPercentage.map((asset, index) => (
-                    <React.Fragment key={index}>
-                      <div className="flex flex-col space-y-1">
-                        <div className="text-[20px] font-[500] text-gray-800">
-                          Token {index + 1}
-                        </div>
-                        <div className="text-[14px] font-bold text-gray-900">
-                          {asset.percentage}%
-                        </div>
+            <div className="flex items-center gap-4 mt-auto">
+              {fungibleAssetsWithPercentage.length === 0 ? (
+                <div className="text-[12px] text-[rgba(0,0,0,0.45)] font-geist">No tokens found</div>
+              ) : (
+                fungibleAssetsWithPercentage.map((asset, index) => (
+                  <React.Fragment key={index}>
+                    <div className="flex flex-col gap-0.5">
+                      <div className="text-[12px] text-[rgba(0,0,0,0.55)] font-geist font-[500]">
+                        Token {index + 1}
                       </div>
-                      {index < fungibleAssetsWithPercentage.length - 1 && (
-                        <div className="w-[0.5px] h-[27px] bg-[#FF5500]"></div>
-                      )}
-                    </React.Fragment>
-                  ))}
-                  {fungibleAssetsWithPercentage.length === 0 && (
-                    <div className="text-gray-500 text-sm">No tokens found</div>
-                  )}
-                </div>
-              </div>
+                      <div className="text-[18px] font-[600] text-[#111] font-geist leading-none">
+                        {asset.percentage}%
+                      </div>
+                    </div>
+                    {index < fungibleAssetsWithPercentage.length - 1 && (
+                      <div className="w-px h-[28px] bg-[rgba(0,0,0,0.08)]"></div>
+                    )}
+                  </React.Fragment>
+                ))
+              )}
             </div>
           </div>
         </div>
-        <div className="p-2">
+        <div className="mt-4">
           <TokenHoldings fungibleAssets={fungibleAssets} isLoading={syncingState} />
         </div>
       </div>

--- a/bin/coordinator-frontend/src/app/dashboard/components/PendingActions.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/PendingActions.tsx
@@ -63,17 +63,17 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
   };
 
   return (
-    <div className="flex flex-col gap-2 border-[0.5px] border-[#00000033] p-4 font-dmmono w-full">
+    <div className="flex flex-col gap-2 border-[0.5px] border-[#00000033] rounded-[10px] p-4 font-geist w-full">
       <div className="flex justify-between items-center">
         <div className="#00000099 font-[500] text-[#00000099] text-[16px]">
-          PENDING ACTIONS
+          Pending Actions
         </div>
         {fixedHeight && (
           <button
             onClick={handleViewAll}
-            className="font-dmmono font-[500] text-[#000000] text-[10px] italic hover:text-[#FF5500] transition-colors cursor-pointer"
+            className="font-geist font-[500] text-[#000000] text-[10px] italic hover:text-[#FF5500] transition-colors cursor-pointer"
           >
-            VIEW ALL
+            View all
           </button>
         )}
       </div>
@@ -92,7 +92,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
           <div className="flex items-center justify-center py-8">
             <div className="flex flex-col items-center gap-3">
               <div className="animate-spin rounded-full h-8 w-8 border-2 border-[#00000033] border-t-[#FF5500]"></div>
-              <p className="text-[#00000099] font-dmmono text-sm font-[400]">
+              <p className="text-[#00000099] font-geist text-sm font-[400]">
                 Syncing proposals...
               </p>
             </div>
@@ -113,21 +113,21 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
             return (
               <div
                 key={proposal.id}
-                className="flex h-[64px] w-full flex-row items-center border-[0.5px] border-[#00000033] flex-shrink-0"
+                className="flex h-[64px] w-full flex-row items-center border border-[rgba(0,0,0,0.08)] rounded-[8px] flex-shrink-0"
               >
-                <div className="font-dmmono w-[10%] text-center text-[12px] font-[400]">
+                <div className="font-geist w-[10%] text-center text-[12px] font-[400]">
                   {proposal.id.slice(0, 8)}...
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
-                <div className="font-dmmono w-[45%] pl-6 text-[12px] font-[400]">
-                  <span className="font-dmmono text-[12px] font-[500]">
-                    {proposal.metadata?.proposalType === 'p2id' ? 'SEND' :
-                     proposal.metadata?.proposalType === 'consume_notes' ? 'RECEIVE' :
-                     proposal.metadata?.proposalType === 'add_signer' ? 'ADD SIGNER' :
-                     proposal.metadata?.proposalType === 'remove_signer' ? 'REMOVE SIGNER' :
-                     proposal.metadata?.proposalType === 'change_threshold' ? 'CHANGE THRESHOLD' :
-                     proposal.metadata?.proposalType === 'switch_psm' ? 'SWITCH PSM' :
-                     (proposal.metadata?.proposalType ?? 'UNKNOWN').toUpperCase()}
+                <div className="font-geist w-[45%] pl-6 text-[12px] font-[400]">
+                  <span className="font-geist text-[12px] font-[500]">
+                    {proposal.metadata?.proposalType === 'p2id' ? 'Send' :
+                     proposal.metadata?.proposalType === 'consume_notes' ? 'Receive' :
+                     proposal.metadata?.proposalType === 'add_signer' ? 'Add signer' :
+                     proposal.metadata?.proposalType === 'remove_signer' ? 'Remove signer' :
+                     proposal.metadata?.proposalType === 'change_threshold' ? 'Change threshold' :
+                     proposal.metadata?.proposalType === 'switch_psm' ? 'Switch PSM' :
+                     (proposal.metadata?.proposalType ?? 'Unknown')}
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
@@ -141,19 +141,19 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
                 <div className="flex w-[15%] space-x-1 flex-row items-center justify-center">
-                  <span className="text-[12px] font-dmmono font-[400]">
+                  <span className="text-[12px] font-geist font-[400]">
                     {sigCount}/{propThreshold} signed
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
                 <div className="flex items-center justify-center w-[10%]">
                   {isReady ? (
-                    <div className="bg-[#28A857] text-white p-1.5 text-[8px] font-dmmono font-[400]">
-                      READY
+                    <div className="bg-[#28A857] text-white p-1.5 text-[8px] font-geist font-[400]">
+                      Ready
                     </div>
                   ) : (
-                    <div className="bg-[#FF5500] text-white p-1.5 text-[8px] font-dmmono font-[400]">
-                      {propThreshold - sigCount} NEEDED
+                    <div className="bg-[#FF5500] text-white p-1.5 text-[8px] font-geist font-[400]">
+                      {propThreshold - sigCount} needed
                     </div>
                   )}
                 </div>
@@ -162,7 +162,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                   <button
                     onClick={() => handleExecute(proposal.id)}
                     disabled={isExecuting}
-                    className={`w-[10%] text-center text-[12px] font-dmmono font-[400] ${
+                    className={`w-[10%] text-center text-[12px] font-geist font-[400] ${
                       isExecuting ? "opacity-50 cursor-not-allowed" : "hover:bg-green-50 text-green-700"
                     }`}
                   >
@@ -172,14 +172,14 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                         <span>...</span>
                       </div>
                     ) : (
-                      "EXECUTE"
+                      "Execute"
                     )}
                   </button>
                 ) : (
                   <button
                     onClick={() => handleSign(proposal.id)}
                     disabled={isSigning}
-                    className={`w-[10%] text-center text-[12px] font-dmmono font-[400] ${
+                    className={`w-[10%] text-center text-[12px] font-geist font-[400] ${
                       isSigning ? "opacity-50 cursor-not-allowed" : "hover:bg-gray-100"
                     }`}
                   >
@@ -189,7 +189,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                         <span>Signing...</span>
                       </div>
                     ) : (
-                      "SIGN"
+                      "Sign"
                     )}
                   </button>
                 )}
@@ -213,10 +213,10 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                 />
               </svg>
             </div>
-            <p className="text-gray-500 font-dmmono text-sm font-[400]">
+            <p className="text-gray-500 font-geist text-sm font-[400]">
               No pending proposals
             </p>
-            <p className="text-gray-400 font-dmmono text-xs font-[400] mt-1">
+            <p className="text-gray-400 font-geist text-xs font-[400] mt-1">
               All proposals have been processed
             </p>
           </div>
@@ -230,7 +230,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: -100, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeOut" }}
-            className={`fixed top-4 right-4 z-50 px-6 py-3 rounded-lg shadow-lg font-dmmono text-sm font-medium ${notification.type === "success"
+            className={`fixed top-4 right-4 z-50 px-6 py-3 rounded-lg shadow-lg font-geist text-sm font-medium ${notification.type === "success"
               ? "bg-green-500 text-white"
               : "bg-red-500 text-white"
               }`}

--- a/bin/coordinator-frontend/src/app/dashboard/components/PendingActions.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/PendingActions.tsx
@@ -63,7 +63,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
   };
 
   return (
-    <div className="flex flex-col gap-2 border-[0.5px] border-[#00000033] rounded-[10px] p-4 font-geist w-full">
+    <div className="flex flex-col gap-2 border border-border-soft rounded-[10px] p-4 w-full">
       <div className="flex justify-between items-center">
         <div className="#00000099 font-[500] text-[#00000099] text-[16px]">
           Pending Actions
@@ -71,7 +71,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
         {fixedHeight && (
           <button
             onClick={handleViewAll}
-            className="font-geist font-[500] text-[#000000] text-[10px] italic hover:text-[#FF5500] transition-colors cursor-pointer"
+            className="font-[500] text-[#000000] text-[10px] italic hover:text-[#FF5500] transition-colors cursor-pointer"
           >
             View all
           </button>
@@ -92,7 +92,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
           <div className="flex items-center justify-center py-8">
             <div className="flex flex-col items-center gap-3">
               <div className="animate-spin rounded-full h-8 w-8 border-2 border-[#00000033] border-t-[#FF5500]"></div>
-              <p className="text-[#00000099] font-geist text-sm font-[400]">
+              <p className="text-[#00000099] text-sm font-[400]">
                 Syncing proposals...
               </p>
             </div>
@@ -115,12 +115,12 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                 key={proposal.id}
                 className="flex h-[64px] w-full flex-row items-center border border-[rgba(0,0,0,0.08)] rounded-[8px] flex-shrink-0"
               >
-                <div className="font-geist w-[10%] text-center text-[12px] font-[400]">
+                <div className="w-[10%] text-center text-[12px] font-[400]">
                   {proposal.id.slice(0, 8)}...
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
-                <div className="font-geist w-[45%] pl-6 text-[12px] font-[400]">
-                  <span className="font-geist text-[12px] font-[500]">
+                <div className="w-[45%] pl-6 text-[12px] font-[400]">
+                  <span className="text-[12px] font-[500]">
                     {proposal.metadata?.proposalType === 'p2id' ? 'Send' :
                      proposal.metadata?.proposalType === 'consume_notes' ? 'Receive' :
                      proposal.metadata?.proposalType === 'add_signer' ? 'Add signer' :
@@ -141,18 +141,18 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
                 <div className="flex w-[15%] space-x-1 flex-row items-center justify-center">
-                  <span className="text-[12px] font-geist font-[400]">
+                  <span className="text-[12px] font-[400]">
                     {sigCount}/{propThreshold} signed
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
                 <div className="flex items-center justify-center w-[10%]">
                   {isReady ? (
-                    <div className="bg-[#28A857] text-white p-1.5 text-[8px] font-geist font-[400]">
+                    <div className="bg-[#28A857] text-white p-1.5 text-[8px] font-[400]">
                       Ready
                     </div>
                   ) : (
-                    <div className="bg-[#FF5500] text-white p-1.5 text-[8px] font-geist font-[400]">
+                    <div className="bg-[#FF5500] text-white p-1.5 text-[8px] font-[400]">
                       {propThreshold - sigCount} needed
                     </div>
                   )}
@@ -162,7 +162,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                   <button
                     onClick={() => handleExecute(proposal.id)}
                     disabled={isExecuting}
-                    className={`w-[10%] text-center text-[12px] font-geist font-[400] ${
+                    className={`w-[10%] text-center text-[12px] font-[400] ${
                       isExecuting ? "opacity-50 cursor-not-allowed" : "hover:bg-green-50 text-green-700"
                     }`}
                   >
@@ -179,7 +179,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                   <button
                     onClick={() => handleSign(proposal.id)}
                     disabled={isSigning}
-                    className={`w-[10%] text-center text-[12px] font-geist font-[400] ${
+                    className={`w-[10%] text-center text-[12px] font-[400] ${
                       isSigning ? "opacity-50 cursor-not-allowed" : "hover:bg-gray-100"
                     }`}
                   >
@@ -213,10 +213,10 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
                 />
               </svg>
             </div>
-            <p className="text-gray-500 font-geist text-sm font-[400]">
+            <p className="text-gray-500 text-sm font-[400]">
               No pending proposals
             </p>
-            <p className="text-gray-400 font-geist text-xs font-[400] mt-1">
+            <p className="text-gray-400 text-xs font-[400] mt-1">
               All proposals have been processed
             </p>
           </div>
@@ -230,7 +230,7 @@ const PendingActions: React.FC<PendingActionsProps> = ({ threshold, fixedHeight 
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: -100, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeOut" }}
-            className={`fixed top-4 right-4 z-50 px-6 py-3 rounded-lg shadow-lg font-geist text-sm font-medium ${notification.type === "success"
+            className={`fixed top-4 right-4 z-50 px-6 py-3 rounded-lg shadow-lg text-sm font-medium ${notification.type === "success"
               ? "bg-green-500 text-white"
               : "bg-red-500 text-white"
               }`}

--- a/bin/coordinator-frontend/src/app/dashboard/components/RecentTransactions.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/RecentTransactions.tsx
@@ -26,13 +26,13 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
     <div className="flex flex-col gap-2 w-full border rounded-[10px] p-4">
       {/* Header */}
       <div className="flex justify-between items-center">
-        <div className="text-[16px] font-geist font-[500] text-[#00000099]">
+        <div className="text-[16px] font-[500] text-[#00000099]">
           Recent Transactions
         </div>
         {fixedHeight && (
           <button
             onClick={handleViewAll}
-            className="text-[10px] font-geist font-[500] text-[#000000] italic hover:text-[#FF5500] transition-colors cursor-pointer"
+            className="text-[10px] font-[500] text-[#000000] italic hover:text-[#FF5500] transition-colors cursor-pointer"
           >
             View all
           </button>
@@ -54,7 +54,7 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
           <div className="flex items-center justify-center py-8">
             <div className="flex flex-col items-center gap-3">
               <div className="animate-spin rounded-full h-8 w-8 border-2 border-[#00000033] border-t-[#FF5500]"></div>
-              <p className="text-[#00000099] font-geist text-sm font-[400]">
+              <p className="text-[#00000099] text-sm font-[400]">
                 Syncing...
               </p>
             </div>
@@ -101,13 +101,13 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
                 <div className="flex w-[15%] space-x-1 flex-row items-center justify-center">
-                  <span className="text-[12px] text-[#FF5500] font-geist font-[400]">
+                  <span className="text-[12px] text-[#FF5500] font-[400]">
                     {sigCount}/{propThreshold} signed
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
-                <div className="w-[10%] text-center text-[12px] font-geist font-[400]">
-                  <span className={`text-[10px] font-geist whitespace-nowrap ${
+                <div className="w-[10%] text-center text-[12px] font-[400]">
+                  <span className={`text-[10px] whitespace-nowrap ${
                     isExecuted ? "text-[#28A857]" : "text-[#FF5500]"
                   }`}>
                     {isExecuted ? "Executed" : "Pending"}
@@ -134,10 +134,10 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
                 />
               </svg>
             </div>
-            <p className="text-gray-500 font-geist text-sm font-[400]">
+            <p className="text-gray-500 text-sm font-[400]">
               No recent transactions
             </p>
-            <p className="text-gray-400 font-geist text-xs font-[400] mt-1">
+            <p className="text-gray-400 text-xs font-[400] mt-1">
               Your transaction history will appear here
             </p>
           </div>

--- a/bin/coordinator-frontend/src/app/dashboard/components/RecentTransactions.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/RecentTransactions.tsx
@@ -23,18 +23,18 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
   };
 
   return (
-    <div className="flex flex-col gap-2 w-full border p-4">
+    <div className="flex flex-col gap-2 w-full border rounded-[10px] p-4">
       {/* Header */}
       <div className="flex justify-between items-center">
-        <div className="text-[16px] font-dmmono font-[500] text-[#00000099]">
-          RECENT TRANSACTIONS
+        <div className="text-[16px] font-geist font-[500] text-[#00000099]">
+          Recent Transactions
         </div>
         {fixedHeight && (
           <button
             onClick={handleViewAll}
-            className="text-[10px] font-dmmono font-[500] text-[#000000] italic hover:text-[#FF5500] transition-colors cursor-pointer"
+            className="text-[10px] font-geist font-[500] text-[#000000] italic hover:text-[#FF5500] transition-colors cursor-pointer"
           >
-            VIEW ALL
+            View all
           </button>
         )}
       </div>
@@ -54,7 +54,7 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
           <div className="flex items-center justify-center py-8">
             <div className="flex flex-col items-center gap-3">
               <div className="animate-spin rounded-full h-8 w-8 border-2 border-[#00000033] border-t-[#FF5500]"></div>
-              <p className="text-[#00000099] font-dmmono text-sm font-[400]">
+              <p className="text-[#00000099] font-geist text-sm font-[400]">
                 Syncing...
               </p>
             </div>
@@ -73,21 +73,21 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
             return (
               <div
                 key={proposal.id}
-                className="flex h-[64px] w-full flex-row items-center relative border-[0.5px] border-[#00000033] flex-shrink-0"
+                className="flex h-[64px] w-full flex-row items-center relative border border-[rgba(0,0,0,0.08)] rounded-[8px] flex-shrink-0"
               >
-                <div className="font-dmmono w-[10%] text-center text-[12px] font-[400]">
+                <div className="font-geist w-[10%] text-center text-[12px] font-[400]">
                   {proposal.id.slice(0, 8)}...
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
-                <div className="font-dmmono w-[45%] pl-6 text-[12px] font-[400]">
-                  <span className="font-dmmono text-[12px] font-[500]">
-                    {proposal.metadata?.proposalType === 'p2id' ? 'SEND Transaction' :
-                     proposal.metadata?.proposalType === 'consume_notes' ? 'RECEIVE Transaction' :
-                     proposal.metadata?.proposalType === 'add_signer' ? 'ADD SIGNER' :
-                     proposal.metadata?.proposalType === 'remove_signer' ? 'REMOVE SIGNER' :
-                     proposal.metadata?.proposalType === 'change_threshold' ? 'CHANGE THRESHOLD' :
-                     proposal.metadata?.proposalType === 'switch_psm' ? 'SWITCH PSM' :
-                     (proposal.metadata?.proposalType ?? 'UNKNOWN').toUpperCase()}
+                <div className="font-geist w-[45%] pl-6 text-[12px] font-[400]">
+                  <span className="font-geist text-[12px] font-[500]">
+                    {proposal.metadata?.proposalType === 'p2id' ? 'Send transaction' :
+                     proposal.metadata?.proposalType === 'consume_notes' ? 'Receive transaction' :
+                     proposal.metadata?.proposalType === 'add_signer' ? 'Add signer' :
+                     proposal.metadata?.proposalType === 'remove_signer' ? 'Remove signer' :
+                     proposal.metadata?.proposalType === 'change_threshold' ? 'Change threshold' :
+                     proposal.metadata?.proposalType === 'switch_psm' ? 'Switch PSM' :
+                     (proposal.metadata?.proposalType ?? 'Unknown')}
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
@@ -101,16 +101,16 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
                 <div className="flex w-[15%] space-x-1 flex-row items-center justify-center">
-                  <span className="text-[12px] text-[#FF5500] font-dmmono font-[400]">
+                  <span className="text-[12px] text-[#FF5500] font-geist font-[400]">
                     {sigCount}/{propThreshold} signed
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
-                <div className="w-[10%] text-center text-[12px] font-dmmono font-[400]">
-                  <span className={`text-[10px] font-dmmono whitespace-nowrap ${
+                <div className="w-[10%] text-center text-[12px] font-geist font-[400]">
+                  <span className={`text-[10px] font-geist whitespace-nowrap ${
                     isExecuted ? "text-[#28A857]" : "text-[#FF5500]"
                   }`}>
-                    {isExecuted ? "EXECUTED" : "PENDING"}
+                    {isExecuted ? "Executed" : "Pending"}
                   </span>
                 </div>
                 <div className="h-full w-[0.5px] bg-[#00000033]"></div>
@@ -134,10 +134,10 @@ const RecentTransactions: React.FC<RecentTransactionsProps> = ({ threshold, fixe
                 />
               </svg>
             </div>
-            <p className="text-gray-500 font-dmmono text-sm font-[400]">
+            <p className="text-gray-500 font-geist text-sm font-[400]">
               No recent transactions
             </p>
-            <p className="text-gray-400 font-dmmono text-xs font-[400] mt-1">
+            <p className="text-gray-400 font-geist text-xs font-[400] mt-1">
               Your transaction history will appear here
             </p>
           </div>

--- a/bin/coordinator-frontend/src/app/dashboard/components/Sidebar.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/Sidebar.tsx
@@ -13,7 +13,12 @@ const sidebarPages: SidebarPage[] = [
   { pageName: "Settings", path: "/dashboard/settings", pageIcon: media.settingsIcon },
 ];
 
-const Sidebar: React.FC = () => {
+interface SidebarProps {
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ collapsed, setCollapsed }) => {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -26,42 +31,60 @@ const Sidebar: React.FC = () => {
   };
 
   const handleLogout = () => {
-    // Clear localStorage
     localStorage.clear();
-    
-    // Clear cookies
     document.cookie.split(";").forEach((c) => {
       document.cookie = c
         .replace(/^ +/, "")
         .replace(/=.*/, "=;expires=" + new Date().toUTCString() + ";path=/");
     });
-    
-    // Reload the page
     window.location.reload();
   };
 
   return (
-    <div className="relative w-[50px] lg:w-[120px] h-full flex flex-col">
-      {/* Right border, only 50vh tall */}
-      <div className="absolute top-0 right-0 w-px h-[75vh] bg-[#0000001A]" />
+    <div className="relative w-full h-full flex flex-col bg-[#f9f9f9]">
+      {/* Collapse toggle */}
+      <div className="flex justify-end px-3 pt-4">
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="w-8 h-8 flex items-center justify-center rounded-md hover:bg-[rgba(0,0,0,0.04)] text-[rgba(0,0,0,0.6)] hover:text-[#111] transition-colors"
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className={`w-4 h-4 transition-transform duration-300 ${collapsed ? "rotate-180" : ""}`}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+          </svg>
+        </button>
+      </div>
 
-      <div className="flex flex-col text-center py-5 flex-1">
+      <div className="flex flex-col pt-4 pb-3 gap-1 flex-1">
         {sidebarPages.map((page, index) => (
           <div
             key={index}
-            className={`py-2 px-3 flex items-center gap-1 cursor-pointer ${
-              isActive(page.path) ? 'bg-[#FF5500] bg-opacity-10 rounded-md' : ''
+            className={`mx-3 py-2.5 px-3 flex items-center gap-3 cursor-pointer rounded-[8px] transition-colors ${
+              isActive(page.path)
+                ? "bg-[#FF5500]/10"
+                : "hover:bg-[rgba(0,0,0,0.04)]"
             }`}
             onClick={() => handleNavigation(page.path)}
           >
-            <div className="w-[100%] lg:w-[15%] h-[20px] relative">
+            <div className="w-[20px] h-[20px] relative shrink-0">
               <Image src={page.pageIcon} alt={page.pageName} quality={100} fill />
             </div>
-            <div className={`lg:block hidden text-[10px] text-left font-[500] lg:w-[85%] px-2 hover:text-[#FF5500] ${
-              isActive(page.path) ? 'text-[#FF5500]' : ''
-            }`}>
-              {page.pageName}
-            </div>
+            {!collapsed && (
+              <div
+                className={`text-[13px] font-geist font-[500] whitespace-nowrap ${
+                  isActive(page.path) ? "text-[#FF5500]" : "text-[#111]"
+                }`}
+              >
+                {page.pageName}
+              </div>
+            )}
           </div>
         ))}
       </div>
@@ -69,10 +92,10 @@ const Sidebar: React.FC = () => {
       {/* Logout button at the bottom */}
       <div className="mt-auto mb-4">
         <div
-          className="py-2 px-3 flex items-center gap-1 cursor-pointer hover:bg-red-50 rounded-md"
+          className="mx-3 py-2.5 px-3 flex items-center gap-3 cursor-pointer hover:bg-red-50 rounded-[8px] transition-colors"
           onClick={handleLogout}
         >
-          <div className="w-[100%] lg:w-[15%] h-[20px] relative flex items-center justify-center">
+          <div className="w-[20px] h-[20px] relative flex items-center justify-center shrink-0">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -88,12 +111,13 @@ const Sidebar: React.FC = () => {
               />
             </svg>
           </div>
-          <div className="lg:block hidden text-[12px] text-left font-[500] lg:w-[85%] px-2 hover:text-red-500 text-gray-700">
-            Logout
-          </div>
+          {!collapsed && (
+            <div className="text-[13px] font-geist font-[500] whitespace-nowrap text-gray-700 hover:text-red-500">
+              Logout
+            </div>
+          )}
         </div>
       </div>
-    
     </div>
   );
 };

--- a/bin/coordinator-frontend/src/app/dashboard/components/Sidebar.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/Sidebar.tsx
@@ -78,7 +78,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed, setCollapsed }) => {
             </div>
             {!collapsed && (
               <div
-                className={`text-[13px] font-geist font-[500] whitespace-nowrap ${
+                className={`text-[13px] font-[500] whitespace-nowrap ${
                   isActive(page.path) ? "text-[#FF5500]" : "text-[#111]"
                 }`}
               >
@@ -112,7 +112,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed, setCollapsed }) => {
             </svg>
           </div>
           {!collapsed && (
-            <div className="text-[13px] font-geist font-[500] whitespace-nowrap text-gray-700 hover:text-red-500">
+            <div className="text-[13px] font-[500] whitespace-nowrap text-gray-700 hover:text-red-500">
               Logout
             </div>
           )}

--- a/bin/coordinator-frontend/src/app/dashboard/components/Taskbar.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/Taskbar.tsx
@@ -64,39 +64,45 @@ const TaskBar: React.FC<TaskBarProps> = () => {
   };
 
   return (
-    <div className="border-b-[0.5px] border-[#0000001A] p-2 bg-white">
+    <div className="border-b border-[rgba(0,0,0,0.06)] px-4 py-3 bg-white">
       <div className="flex items-center justify-between">
-        {/* Left side - Account info */}
-        <div className="flex items-center">
-          <Image src={media.greyBox} alt="greyBox" quality={100} />
-          <div className="flex flex-col px-2">
-            <div className="text-[10px] md:text-[13px] text-[#000000] font-[500] font-dmmono">
+        {/* Left side - Account info — width matches sidebar */}
+        <div className="w-[220px] flex items-center justify-center shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-[8px] bg-[#DFD8D3] flex items-center justify-center shrink-0">
+            <span className="text-[13px] font-geist font-[600] text-[#FF5500]">
+              {walletName.slice(0, 1).toUpperCase()}
+            </span>
+          </div>
+          <div className="flex flex-col">
+            <div className="text-[13px] text-[#111] font-geist font-[600]">
               {walletName}
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
               <div
-                className="text-[7px] md:text-[10px] text-[#000000] font-[500] font-dmmono cursor-help"
+                className="text-[11px] text-[rgba(0,0,0,0.5)] font-geist font-[400] cursor-help"
                 title={accountId || "No Account ID"}
               >
                 {accountId ? truncateHex(accountId, 8, 6) : "No Account"}
               </div>
               <button
                 onClick={copyAccountId}
-                className="flex items-center justify-center w-4 h-4 bg-gray-100 hover:bg-gray-200 rounded transition-colors duration-150"
+                className="flex items-center justify-center w-4 h-4 hover:bg-[rgba(0,0,0,0.05)] rounded transition-colors"
                 title="Copy account ID"
               >
                 {isCopied ? (
-                  <svg className="w-2.5 h-2.5 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                  <svg className="w-3 h-3 text-[rgba(46,161,80,1)]" fill="currentColor" viewBox="0 0 20 20">
                     <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                   </svg>
                 ) : (
-                  <svg className="w-2.5 h-2.5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-3 h-3 text-[rgba(0,0,0,0.4)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                   </svg>
                 )}
               </button>
             </div>
           </div>
+        </div>
         </div>
 
         {/* Center - PSM Status & Wallet Source */}
@@ -105,17 +111,17 @@ const TaskBar: React.FC<TaskBarProps> = () => {
           <div className="relative">
             <button
               onClick={() => { setShowPsmEditor(!showPsmEditor); setPsmUrlDraft(psmUrl); }}
-              className={`flex items-center gap-1.5 px-2 py-1 rounded text-[9px] font-dmmono font-[500] border transition-colors ${
+              className={`flex items-center gap-1.5 h-8 px-3 rounded-full text-[11px] font-geist font-[500] transition-colors ${
                 psmStatus === 'connected'
-                  ? 'border-green-300 bg-green-50 text-green-700'
+                  ? 'bg-[rgba(46,161,80,0.08)] text-[rgba(46,161,80,1)] hover:bg-[rgba(46,161,80,0.12)]'
                   : psmStatus === 'connecting'
-                    ? 'border-yellow-300 bg-yellow-50 text-yellow-700'
-                    : 'border-red-300 bg-red-50 text-red-700'
+                    ? 'bg-[rgba(234,179,8,0.08)] text-[rgba(180,140,0,1)] hover:bg-[rgba(234,179,8,0.12)]'
+                    : 'bg-[rgba(220,38,38,0.08)] text-[rgba(220,38,38,1)] hover:bg-[rgba(220,38,38,0.12)]'
               }`}
             >
               <span className={`w-1.5 h-1.5 rounded-full ${
-                psmStatus === 'connected' ? 'bg-green-500' :
-                psmStatus === 'connecting' ? 'bg-yellow-500 animate-pulse' : 'bg-red-500'
+                psmStatus === 'connected' ? 'bg-[rgba(46,161,80,1)]' :
+                psmStatus === 'connecting' ? 'bg-[rgba(234,179,8,1)] animate-pulse' : 'bg-[rgba(220,38,38,1)]'
               }`} />
               PSM {psmStatus}
             </button>
@@ -123,23 +129,23 @@ const TaskBar: React.FC<TaskBarProps> = () => {
             {/* PSM Endpoint Editor Popover */}
             {showPsmEditor && (
               <div className="absolute top-full left-0 mt-1 z-50 bg-white border border-gray-200 rounded shadow-lg p-3 w-[320px]">
-                <div className="text-[10px] font-dmmono font-[500] mb-1 uppercase">PSM Endpoint</div>
+                <div className="text-[10px] font-geist font-[500] mb-1">PSM Endpoint</div>
                 <input
                   type="text"
                   value={psmUrlDraft}
                   onChange={(e) => setPsmUrlDraft(e.target.value)}
-                  className="w-full text-[11px] font-dmmono border border-gray-200 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-1 focus:ring-[#FF5500]"
+                  className="w-full text-[11px] font-geist border border-gray-200 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-1 focus:ring-[#FF5500]"
                 />
                 <div className="flex gap-2">
                   <button
                     onClick={handlePsmReconnect}
-                    className="flex-1 bg-[#FF5500] text-white text-[10px] font-dmmono px-2 py-1 rounded hover:bg-[#E04A00] transition-colors"
+                    className="flex-1 bg-[#FF5500] text-white text-[10px] font-geist px-2 py-1 rounded hover:bg-[#E04A00] transition-colors"
                   >
                     RECONNECT
                   </button>
                   <button
                     onClick={() => setShowPsmEditor(false)}
-                    className="flex-1 border border-gray-200 text-[10px] font-dmmono px-2 py-1 rounded hover:bg-gray-50 transition-colors"
+                    className="flex-1 border border-gray-200 text-[10px] font-geist px-2 py-1 rounded hover:bg-gray-50 transition-colors"
                   >
                     CANCEL
                   </button>
@@ -148,15 +154,17 @@ const TaskBar: React.FC<TaskBarProps> = () => {
             )}
           </div>
 
-          {/* Wallet Source Selector */}
-          <div className="flex items-center gap-1">
+          {/* Wallet Source Selector — segmented control */}
+          <div className="flex items-center h-8 bg-[rgba(245,245,245,1)] rounded-[8px] p-0.5">
             <button
               onClick={() => setWalletSource('local')}
-              className={`px-2 py-1 text-[9px] font-dmmono font-[500] border rounded transition-colors ${
-                walletSource === 'local' ? 'bg-[#FF5500] text-white border-[#FF5500]' : 'bg-white text-gray-600 border-gray-200 hover:border-[#FF5500]'
+              className={`flex items-center px-3 h-full text-[11px] font-geist font-[500] rounded-[6px] transition-all ${
+                walletSource === 'local'
+                  ? 'bg-white text-[#FF5500] shadow-sm'
+                  : 'text-[rgba(0,0,0,0.55)] hover:text-[#111]'
               }`}
             >
-              LOCAL
+              Local
             </button>
             <button
               onClick={() => {
@@ -166,11 +174,13 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                   openParaModal();
                 }
               }}
-              className={`px-2 py-1 text-[9px] font-dmmono font-[500] border rounded transition-colors ${
-                walletSource === 'para' ? 'bg-[#FF5500] text-white border-[#FF5500]' : 'bg-white text-gray-600 border-gray-200 hover:border-[#FF5500]'
+              className={`flex items-center px-3 h-full text-[11px] font-geist font-[500] rounded-[6px] transition-all ${
+                walletSource === 'para'
+                  ? 'bg-white text-[#FF5500] shadow-sm'
+                  : 'text-[rgba(0,0,0,0.55)] hover:text-[#111]'
               }`}
             >
-              PARA {paraSession.connected ? '(connected)' : ''}
+              Para{paraSession.connected ? ' ●' : ''}
             </button>
             <button
               onClick={() => {
@@ -180,37 +190,39 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                   connectMidenWallet();
                 }
               }}
-              className={`px-2 py-1 text-[9px] font-dmmono font-[500] border rounded transition-colors ${
-                walletSource === 'miden-wallet' ? 'bg-[#FF5500] text-white border-[#FF5500]' : 'bg-white text-gray-600 border-gray-200 hover:border-[#FF5500]'
+              className={`flex items-center px-3 h-full text-[11px] font-geist font-[500] rounded-[6px] transition-all ${
+                walletSource === 'miden-wallet'
+                  ? 'bg-white text-[#FF5500] shadow-sm'
+                  : 'text-[rgba(0,0,0,0.55)] hover:text-[#111]'
               }`}
             >
-              WALLET {midenWalletSession.connected ? '(connected)' : ''}
+              Wallet{midenWalletSession.connected ? ' ●' : ''}
             </button>
           </div>
         </div>
 
         {/* Right side - Signer Keys & Sync */}
-        <div className="flex items-center gap-2 pr-2">
+        <div className="flex items-center gap-2">
           {/* Active Commitment Display */}
           <div className="relative">
             <button
               onClick={() => setShowSignerKeys(!showSignerKeys)}
-              className="flex items-center gap-1 px-2 py-1 text-[9px] font-dmmono font-[500] border border-gray-200 rounded hover:border-[#FF5500] transition-colors"
+              className="flex items-center gap-2 h-8 px-3 text-[11px] font-geist font-[500] bg-[rgba(245,245,245,1)] rounded-[8px] hover:bg-[rgba(235,235,235,1)] transition-colors"
               title={activeCommitment || "No commitment"}
             >
-              <span className="text-gray-500">{activeScheme.toUpperCase()}</span>
-              <span>{activeCommitment ? truncateHex(activeCommitment, 6, 4) : generatingSigner ? 'Generating...' : 'N/A'}</span>
+              <span className="text-[rgba(0,0,0,0.5)]">{activeScheme.toUpperCase()}</span>
+              <span className="text-[#111]">{activeCommitment ? truncateHex(activeCommitment, 6, 4) : generatingSigner ? 'Generating...' : 'N/A'}</span>
             </button>
 
             {/* Signer Keys Popover */}
             {showSignerKeys && signer && (
               <div className="absolute top-full right-0 mt-1 z-50 bg-white border border-gray-200 rounded shadow-lg p-3 w-[360px]">
-                <div className="text-[10px] font-dmmono font-[500] mb-2 uppercase">Local Signer Keys</div>
+                <div className="text-[10px] font-geist font-[500] mb-2">Local Signer Keys</div>
                 <div className="space-y-2">
                   <div>
-                    <div className="text-[9px] font-dmmono text-gray-500 uppercase">Falcon Commitment</div>
+                    <div className="text-[9px] font-geist text-gray-500">Falcon Commitment</div>
                     <div
-                      className="text-[10px] font-dmmono bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
+                      className="text-[10px] font-geist bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
                       onClick={() => copyToClipboard(signer.falcon.commitment, () => toast.success("Falcon commitment copied"))}
                       title="Click to copy"
                     >
@@ -218,9 +230,9 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                     </div>
                   </div>
                   <div>
-                    <div className="text-[9px] font-dmmono text-gray-500 uppercase">ECDSA Commitment</div>
+                    <div className="text-[9px] font-geist text-gray-500">ECDSA Commitment</div>
                     <div
-                      className="text-[10px] font-dmmono bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
+                      className="text-[10px] font-geist bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
                       onClick={() => copyToClipboard(signer.ecdsa.commitment, () => toast.success("ECDSA commitment copied"))}
                       title="Click to copy"
                     >
@@ -230,7 +242,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                 </div>
                 <button
                   onClick={() => setShowSignerKeys(false)}
-                  className="mt-2 w-full text-[9px] font-dmmono border border-gray-200 rounded py-1 hover:bg-gray-50"
+                  className="mt-2 w-full text-[9px] font-geist border border-gray-200 rounded py-1 hover:bg-gray-50"
                 >
                   CLOSE
                 </button>
@@ -243,16 +255,16 @@ const TaskBar: React.FC<TaskBarProps> = () => {
             <button
               onClick={handleSync}
               disabled={syncingState}
-              className="px-2 py-1 text-[9px] font-dmmono font-[500] border border-gray-200 rounded hover:border-[#FF5500] hover:bg-[#FF5500]/5 transition-colors disabled:opacity-50"
+              className="flex items-center h-8 px-3 text-[11px] font-geist font-[500] text-[#111] bg-[rgba(245,245,245,1)] rounded-[8px] hover:bg-[rgba(235,235,235,1)] transition-colors disabled:opacity-50"
               title="Sync state"
             >
               {syncingState ? (
-                <span className="flex items-center gap-1">
-                  <span className="animate-spin rounded-full h-2.5 w-2.5 border border-gray-400 border-t-transparent" />
-                  SYNCING
+                <span className="flex items-center gap-1.5">
+                  <span className="animate-spin rounded-full h-3 w-3 border border-gray-400 border-t-transparent" />
+                  Syncing
                 </span>
               ) : (
-                "SYNC"
+                "Sync"
               )}
             </button>
           )}

--- a/bin/coordinator-frontend/src/app/dashboard/components/Taskbar.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/components/Taskbar.tsx
@@ -70,17 +70,17 @@ const TaskBar: React.FC<TaskBarProps> = () => {
         <div className="w-[220px] flex items-center justify-center shrink-0">
         <div className="flex items-center gap-3">
           <div className="w-9 h-9 rounded-[8px] bg-[#DFD8D3] flex items-center justify-center shrink-0">
-            <span className="text-[13px] font-geist font-[600] text-[#FF5500]">
+            <span className="text-[13px] font-[600] text-[#FF5500]">
               {walletName.slice(0, 1).toUpperCase()}
             </span>
           </div>
           <div className="flex flex-col">
-            <div className="text-[13px] text-[#111] font-geist font-[600]">
+            <div className="text-[13px] text-[#111] font-[600]">
               {walletName}
             </div>
             <div className="flex items-center gap-1.5">
               <div
-                className="text-[11px] text-[rgba(0,0,0,0.5)] font-geist font-[400] cursor-help"
+                className="text-[11px] text-[rgba(0,0,0,0.5)] font-[400] cursor-help"
                 title={accountId || "No Account ID"}
               >
                 {accountId ? truncateHex(accountId, 8, 6) : "No Account"}
@@ -111,7 +111,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
           <div className="relative">
             <button
               onClick={() => { setShowPsmEditor(!showPsmEditor); setPsmUrlDraft(psmUrl); }}
-              className={`flex items-center gap-1.5 h-8 px-3 rounded-full text-[11px] font-geist font-[500] transition-colors ${
+              className={`flex items-center gap-1.5 h-8 px-3 rounded-full text-[11px] font-[500] transition-colors ${
                 psmStatus === 'connected'
                   ? 'bg-[rgba(46,161,80,0.08)] text-[rgba(46,161,80,1)] hover:bg-[rgba(46,161,80,0.12)]'
                   : psmStatus === 'connecting'
@@ -129,23 +129,23 @@ const TaskBar: React.FC<TaskBarProps> = () => {
             {/* PSM Endpoint Editor Popover */}
             {showPsmEditor && (
               <div className="absolute top-full left-0 mt-1 z-50 bg-white border border-gray-200 rounded shadow-lg p-3 w-[320px]">
-                <div className="text-[10px] font-geist font-[500] mb-1">PSM Endpoint</div>
+                <div className="text-[10px] font-[500] mb-1">PSM Endpoint</div>
                 <input
                   type="text"
                   value={psmUrlDraft}
                   onChange={(e) => setPsmUrlDraft(e.target.value)}
-                  className="w-full text-[11px] font-geist border border-gray-200 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-1 focus:ring-[#FF5500]"
+                  className="w-full text-[11px] border border-gray-200 rounded px-2 py-1 mb-2 focus:outline-none focus:ring-1 focus:ring-[#FF5500]"
                 />
                 <div className="flex gap-2">
                   <button
                     onClick={handlePsmReconnect}
-                    className="flex-1 bg-[#FF5500] text-white text-[10px] font-geist px-2 py-1 rounded hover:bg-[#E04A00] transition-colors"
+                    className="flex-1 bg-[#FF5500] text-white text-[10px] px-2 py-1 rounded hover:bg-[#E04A00] transition-colors"
                   >
                     RECONNECT
                   </button>
                   <button
                     onClick={() => setShowPsmEditor(false)}
-                    className="flex-1 border border-gray-200 text-[10px] font-geist px-2 py-1 rounded hover:bg-gray-50 transition-colors"
+                    className="flex-1 border border-gray-200 text-[10px] px-2 py-1 rounded hover:bg-gray-50 transition-colors"
                   >
                     CANCEL
                   </button>
@@ -158,7 +158,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
           <div className="flex items-center h-8 bg-[rgba(245,245,245,1)] rounded-[8px] p-0.5">
             <button
               onClick={() => setWalletSource('local')}
-              className={`flex items-center px-3 h-full text-[11px] font-geist font-[500] rounded-[6px] transition-all ${
+              className={`flex items-center px-3 h-full text-[11px] font-[500] rounded-[6px] transition-all ${
                 walletSource === 'local'
                   ? 'bg-white text-[#FF5500] shadow-sm'
                   : 'text-[rgba(0,0,0,0.55)] hover:text-[#111]'
@@ -174,7 +174,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                   openParaModal();
                 }
               }}
-              className={`flex items-center px-3 h-full text-[11px] font-geist font-[500] rounded-[6px] transition-all ${
+              className={`flex items-center px-3 h-full text-[11px] font-[500] rounded-[6px] transition-all ${
                 walletSource === 'para'
                   ? 'bg-white text-[#FF5500] shadow-sm'
                   : 'text-[rgba(0,0,0,0.55)] hover:text-[#111]'
@@ -190,7 +190,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                   connectMidenWallet();
                 }
               }}
-              className={`flex items-center px-3 h-full text-[11px] font-geist font-[500] rounded-[6px] transition-all ${
+              className={`flex items-center px-3 h-full text-[11px] font-[500] rounded-[6px] transition-all ${
                 walletSource === 'miden-wallet'
                   ? 'bg-white text-[#FF5500] shadow-sm'
                   : 'text-[rgba(0,0,0,0.55)] hover:text-[#111]'
@@ -207,7 +207,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
           <div className="relative">
             <button
               onClick={() => setShowSignerKeys(!showSignerKeys)}
-              className="flex items-center gap-2 h-8 px-3 text-[11px] font-geist font-[500] bg-[rgba(245,245,245,1)] rounded-[8px] hover:bg-[rgba(235,235,235,1)] transition-colors"
+              className="flex items-center gap-2 h-8 px-3 text-[11px] font-[500] bg-[rgba(245,245,245,1)] rounded-[8px] hover:bg-[rgba(235,235,235,1)] transition-colors"
               title={activeCommitment || "No commitment"}
             >
               <span className="text-[rgba(0,0,0,0.5)]">{activeScheme.toUpperCase()}</span>
@@ -217,12 +217,12 @@ const TaskBar: React.FC<TaskBarProps> = () => {
             {/* Signer Keys Popover */}
             {showSignerKeys && signer && (
               <div className="absolute top-full right-0 mt-1 z-50 bg-white border border-gray-200 rounded shadow-lg p-3 w-[360px]">
-                <div className="text-[10px] font-geist font-[500] mb-2">Local Signer Keys</div>
+                <div className="text-[10px] font-[500] mb-2">Local Signer Keys</div>
                 <div className="space-y-2">
                   <div>
-                    <div className="text-[9px] font-geist text-gray-500">Falcon Commitment</div>
+                    <div className="text-[9px] text-gray-500">Falcon Commitment</div>
                     <div
-                      className="text-[10px] font-geist bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
+                      className="text-[10px] bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
                       onClick={() => copyToClipboard(signer.falcon.commitment, () => toast.success("Falcon commitment copied"))}
                       title="Click to copy"
                     >
@@ -230,9 +230,9 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                     </div>
                   </div>
                   <div>
-                    <div className="text-[9px] font-geist text-gray-500">ECDSA Commitment</div>
+                    <div className="text-[9px] text-gray-500">ECDSA Commitment</div>
                     <div
-                      className="text-[10px] font-geist bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
+                      className="text-[10px] bg-gray-50 p-1 rounded cursor-pointer hover:bg-gray-100 break-all"
                       onClick={() => copyToClipboard(signer.ecdsa.commitment, () => toast.success("ECDSA commitment copied"))}
                       title="Click to copy"
                     >
@@ -242,7 +242,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
                 </div>
                 <button
                   onClick={() => setShowSignerKeys(false)}
-                  className="mt-2 w-full text-[9px] font-geist border border-gray-200 rounded py-1 hover:bg-gray-50"
+                  className="mt-2 w-full text-[9px] border border-gray-200 rounded py-1 hover:bg-gray-50"
                 >
                   CLOSE
                 </button>
@@ -255,7 +255,7 @@ const TaskBar: React.FC<TaskBarProps> = () => {
             <button
               onClick={handleSync}
               disabled={syncingState}
-              className="flex items-center h-8 px-3 text-[11px] font-geist font-[500] text-[#111] bg-[rgba(245,245,245,1)] rounded-[8px] hover:bg-[rgba(235,235,235,1)] transition-colors disabled:opacity-50"
+              className="flex items-center h-8 px-3 text-[11px] font-[500] text-[#111] bg-[rgba(245,245,245,1)] rounded-[8px] hover:bg-[rgba(235,235,235,1)] transition-colors disabled:opacity-50"
               title="Sync state"
             >
               {syncingState ? (

--- a/bin/coordinator-frontend/src/app/dashboard/home/page.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/home/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useMemo, useState } from "react";
 import Image from "next/image";
-import assetValIcon from "../../../../public/media/home/circum_dollar.svg";
+import media from "../../../../public/media";
 
 import PendingActions from "../components/PendingActions";
 import RecentTransactions from "../components/RecentTransactions";
@@ -45,23 +45,18 @@ const Page: React.FC = () => {
         {/*Total Asset Value Div*/}
         <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
           <div className="flex items-center gap-2.5">
-            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
-              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
-                <circle cx="12" cy="12" r="9"/>
-                <path d="M14.5 9a2.5 2.5 0 0 0-2.5-2h-1a2 2 0 0 0 0 4h2a2 2 0 0 1 0 4h-1a2.5 2.5 0 0 1-2.5-2"/>
-                <line x1="12" y1="6" x2="12" y2="7"/>
-                <line x1="12" y1="17" x2="12" y2="18"/>
-              </svg>
+            <div className="w-7 h-7 rounded-[8px] bg-brand/10 flex items-center justify-center shrink-0">
+              <Image src={media.assetValIcon} alt="" className="w-[16px] h-[16px]" />
             </div>
-            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
+            <div className="text-[14px] md:text-[15px] text-ink font-[600]">
               Total Asset Value
             </div>
           </div>
           <div className="flex flex-col gap-1 mt-auto">
-            <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
+            <div className="text-[28px] md:text-[32px] font-[600] text-[#111] leading-none">
               {totalBalance.toFixed(2)}
             </div>
-            <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+            <div className="text-[11px] md:text-[12px] text-[rgba(0,0,0,0.45)]">
               {vaultBalances.length} token(s) in vault
             </div>
           </div>
@@ -69,36 +64,31 @@ const Page: React.FC = () => {
         {/*Overview Div*/}
         <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
           <div className="flex items-center gap-2.5">
-            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
-              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
-                <rect x="3" y="3" width="7" height="7" rx="1"/>
-                <rect x="14" y="3" width="7" height="7" rx="1"/>
-                <rect x="3" y="14" width="7" height="7" rx="1"/>
-                <rect x="14" y="14" width="7" height="7" rx="1"/>
-              </svg>
+            <div className="w-7 h-7 rounded-[8px] bg-brand/10 flex items-center justify-center shrink-0">
+              <Image src={media.gridOverviewIcon} alt="" className="w-[16px] h-[16px]" />
             </div>
-            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
+            <div className="text-[14px] md:text-[15px] text-ink font-[600]">
               Overview
             </div>
           </div>
           <div className="flex flex-col gap-2 mt-auto">
             <div className="flex items-center justify-between">
-              <div className="text-[12px] md:text-[13px] font-[500] font-geist text-[#111]">Wallet Name</div>
-              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)] font-geist">
+              <div className="text-[12px] md:text-[13px] font-[500] text-[#111]">Wallet Name</div>
+              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)]">
                 {walletName}
               </div>
             </div>
             <div className="h-px w-full bg-[rgba(0,0,0,0.06)]"></div>
             <div className="flex items-center justify-between">
-              <div className="text-[12px] md:text-[13px] font-[500] font-geist text-[#111]">Signers</div>
-              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)] font-geist">
+              <div className="text-[12px] md:text-[13px] font-[500] text-[#111]">Signers</div>
+              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)]">
                 {signerCount}
               </div>
             </div>
             <div className="h-px w-full bg-[rgba(0,0,0,0.06)]"></div>
             <div className="flex items-center justify-between">
-              <div className="text-[12px] md:text-[13px] font-[500] font-geist text-[#111]">Threshold</div>
-              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)] font-geist">
+              <div className="text-[12px] md:text-[13px] font-[500] text-[#111]">Threshold</div>
+              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)]">
                 {threshold > 0 ? `${threshold} of ${signerCount} signatures` : "N/A"}
               </div>
             </div>
@@ -106,34 +96,34 @@ const Page: React.FC = () => {
         </div>
         {/*Actions Div*/}
         <div className="col-span-4 flex flex-col h-[140px] md:h-[160px]">
-          <div className="flex flex-col justify-between gap-2 items-left space-x-2 h-full font-medium font-geist text-black">
+          <div className="flex flex-col justify-between gap-2 items-left space-x-2 h-full font-medium text-black">
 
             <div className="flex flex-col gap-2 h-full">
               <div className="flex flex-row gap-2 h-1/2">
                 <button
-                  className="w-1/2 relative group overflow-hidden border-[0.5px] border-[#00000033] rounded-[10px] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
+                  className="w-1/2 relative group overflow-hidden border border-border-soft rounded-[10px] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
                   onClick={() => setIsInitiateFundTransferOpen(true)}
                 >
-                  <span className="absolute inset-0 bg-[#FF5500] transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
+                  <span className="absolute inset-0 bg-brand transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
                   <span className="relative z-1 transition-colors duration-300 group-hover:text-white">
                     Send
                   </span>
                 </button>
                 <button
-                  className="w-1/2 relative group overflow-hidden border-[0.5px] border-[#00000033] rounded-[10px] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
+                  className="w-1/2 relative group overflow-hidden border border-border-soft rounded-[10px] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
                   onClick={() => setIsReceiveFundTransferOpen(true)}
                 >
-                  <span className="absolute inset-0 bg-[#FF5500] transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
+                  <span className="absolute inset-0 bg-brand transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
                   <span className="relative z-1 transition-colors duration-300 group-hover:text-white">
                     Receive
                   </span>
                 </button>
               </div>
               <button
-                className="w-full relative group overflow-hidden h-1/2 border-[0.5px] border-[#00000033] rounded-[10px] py-1 px-2 text-[12px] md:text-[16px] text-[#000000] font-[400]"
+                className="w-full relative group overflow-hidden h-1/2 border border-border-soft rounded-[10px] py-1 px-2 text-[12px] md:text-[16px] text-[#000000] font-[400]"
                 onClick={() => setIsApproveFundTransferOpen(true)}
               >
-                <span className="absolute inset-0 bg-[#FF5500] transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
+                <span className="absolute inset-0 bg-brand transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
                 <span className="relative z-1 transition-colors duration-300 group-hover:text-white">
                   Approve queued transfers
                 </span>

--- a/bin/coordinator-frontend/src/app/dashboard/home/page.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/home/page.tsx
@@ -43,83 +43,99 @@ const Page: React.FC = () => {
       {/*Top Cards Div*/}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 md:gap-6 px-2 py-2 md:py-3 lg:p-4">
         {/*Total Asset Value Div*/}
-        <div className="col-span-4 flex flex-col justify-between h-[100px] md:h-[135px] border-[0.5px] border-[#00000033] p-2 md:p-3">
-          <div className="flex items-left space-x-2 font-dmmono text-black">
-            <Image src={assetValIcon} alt="assetValIcon" quality={100} />
-            <div className="font-dmmono text-[14px] md:text-[16px] text-[#000000] font-[500]">
+        <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                <circle cx="12" cy="12" r="9"/>
+                <path d="M14.5 9a2.5 2.5 0 0 0-2.5-2h-1a2 2 0 0 0 0 4h2a2 2 0 0 1 0 4h-1a2.5 2.5 0 0 1-2.5-2"/>
+                <line x1="12" y1="6" x2="12" y2="7"/>
+                <line x1="12" y1="17" x2="12" y2="18"/>
+              </svg>
+            </div>
+            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
               Total Asset Value
             </div>
           </div>
-          <div>
-            <div className="text-[18px] md:text-[24px] font-[500] font-dmmono text-[#000000]">
+          <div className="flex flex-col gap-1 mt-auto">
+            <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
               {totalBalance.toFixed(2)}
             </div>
-            <div className="text-xs md:text-sm text-gray-700">{vaultBalances.length} token(s) in vault</div>
+            <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+              {vaultBalances.length} token(s) in vault
+            </div>
           </div>
         </div>
         {/*Overview Div*/}
-        <div className="col-span-4 flex flex-col h-[100px] md:h-[135px] border-[0.5px] border-[#00000033] p-2 md:p-3">
-          <div className="flex flex-col items-left space-x-2 font-dmmono text-black">
-            <div className="flex items-left space-x-2">
-              <Image src={assetValIcon} alt="assetValIcon" quality={100} />
-              <div className="font-dmmono text-[14px] md:text-[16px] text-[#000000] font-[500]">
-                Overview
+        <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                <rect x="3" y="3" width="7" height="7" rx="1"/>
+                <rect x="14" y="3" width="7" height="7" rx="1"/>
+                <rect x="3" y="14" width="7" height="7" rx="1"/>
+                <rect x="14" y="14" width="7" height="7" rx="1"/>
+              </svg>
+            </div>
+            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
+              Overview
+            </div>
+          </div>
+          <div className="flex flex-col gap-2 mt-auto">
+            <div className="flex items-center justify-between">
+              <div className="text-[12px] md:text-[13px] font-[500] font-geist text-[#111]">Wallet Name</div>
+              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)] font-geist">
+                {walletName}
               </div>
             </div>
-            <div className="flex flex-col p-1 md:p-2 gap-1 md:gap-2">
-              <div className="flex items-center justify-between border-b-[0.5px]">
-                <div className="text-[8px] md:text-[10px] font-[500] font-dmmono">Wallet Name</div>
-                <div className="text-[8px] md:text-[10px] text-[#0000008C] font-[500] font-dmmono">
-                  {walletName}
-                </div>
+            <div className="h-px w-full bg-[rgba(0,0,0,0.06)]"></div>
+            <div className="flex items-center justify-between">
+              <div className="text-[12px] md:text-[13px] font-[500] font-geist text-[#111]">Signers</div>
+              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)] font-geist">
+                {signerCount}
               </div>
-              <div className="flex items-center justify-between border-b-[0.5px]">
-                <div className="text-[8px] md:text-[10px] font-[500] font-dmmono">Signers</div>
-                <div className="text-[8px] md:text-[10px] text-[#0000008C] font-[500] font-dmmono">
-                  {signerCount}
-                </div>
-              </div>
-              <div className="flex items-center justify-between border-b-[0.5px]">
-                <div className="text-[8px] md:text-[10px] font-[500] font-dmmono">Threshold</div>
-                <div className="text-[8px] md:text-[10px] text-[#0000008C] font-[500] font-dmmono">
-                  {threshold > 0 ? `${threshold} of ${signerCount} signatures` : "N/A"}
-                </div>
+            </div>
+            <div className="h-px w-full bg-[rgba(0,0,0,0.06)]"></div>
+            <div className="flex items-center justify-between">
+              <div className="text-[12px] md:text-[13px] font-[500] font-geist text-[#111]">Threshold</div>
+              <div className="text-[12px] md:text-[13px] text-[rgba(0,0,0,0.55)] font-geist">
+                {threshold > 0 ? `${threshold} of ${signerCount} signatures` : "N/A"}
               </div>
             </div>
           </div>
         </div>
         {/*Actions Div*/}
-        <div className="col-span-4 flex flex-col h-[100px] md:h-[135px]">
-          <div className="flex flex-col justify-between gap-2 items-left space-x-2 h-full font-medium font-dmmono text-black">
+        <div className="col-span-4 flex flex-col h-[140px] md:h-[160px]">
+          <div className="flex flex-col justify-between gap-2 items-left space-x-2 h-full font-medium font-geist text-black">
 
             <div className="flex flex-col gap-2 h-full">
               <div className="flex flex-row gap-2 h-1/2">
                 <button
-                  className="w-1/2 relative group overflow-hidden border-[0.5px] border-[#00000033] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
+                  className="w-1/2 relative group overflow-hidden border-[0.5px] border-[#00000033] rounded-[10px] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
                   onClick={() => setIsInitiateFundTransferOpen(true)}
                 >
                   <span className="absolute inset-0 bg-[#FF5500] transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
                   <span className="relative z-1 transition-colors duration-300 group-hover:text-white">
-                    SEND
+                    Send
                   </span>
                 </button>
                 <button
-                  className="w-1/2 relative group overflow-hidden border-[0.5px] border-[#00000033] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
+                  className="w-1/2 relative group overflow-hidden border-[0.5px] border-[#00000033] rounded-[10px] py-1 px-2 text-[14px] md:text-[16px] text-[#000000] font-[400]"
                   onClick={() => setIsReceiveFundTransferOpen(true)}
                 >
                   <span className="absolute inset-0 bg-[#FF5500] transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
                   <span className="relative z-1 transition-colors duration-300 group-hover:text-white">
-                    RECEIVE
+                    Receive
                   </span>
                 </button>
               </div>
               <button
-                className="w-full relative group overflow-hidden h-1/2 border-[0.5px] border-[#00000033] py-1 px-2 text-[12px] md:text-[16px] text-[#000000] font-[400]"
+                className="w-full relative group overflow-hidden h-1/2 border-[0.5px] border-[#00000033] rounded-[10px] py-1 px-2 text-[12px] md:text-[16px] text-[#000000] font-[400]"
                 onClick={() => setIsApproveFundTransferOpen(true)}
               >
                 <span className="absolute inset-0 bg-[#FF5500] transform scale-x-0 origin-left transition-transform duration-300 ease-out group-hover:scale-x-100"></span>
                 <span className="relative z-1 transition-colors duration-300 group-hover:text-white">
-                  APPROVE QUEUED TRANSFERS
+                  Approve queued transfers
                 </span>
               </button>
             </div>

--- a/bin/coordinator-frontend/src/app/dashboard/layout.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import Sidebar from "./components/Sidebar";
 import TaskBar from "./components/Taskbar";
 
@@ -12,16 +12,20 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const [collapsed, setCollapsed] = useState(false);
+  const sidebarWidth = collapsed ? 64 : 220;
+
   return (
-    <div className="flex flex-col h-full">
-      <div className="fixed top-0 left-0 right-0 z-10">
-        <TaskBar />
-      </div>
-      <div className="flex h-full pt-8">
-        <aside className="fixed left-0 top-[50px] h-[calc(100vh-4rem)] z-10">
-          <Sidebar />
+    <div className="flex flex-col h-screen overflow-hidden">
+      <TaskBar />
+      <div className="flex flex-1 overflow-hidden">
+        <aside
+          className="shrink-0 overflow-y-auto transition-all duration-300 ease-out"
+          style={{ width: sidebarWidth }}
+        >
+          <Sidebar collapsed={collapsed} setCollapsed={setCollapsed} />
         </aside>
-        <main className="flex-1 ml-[50px] lg:ml-[100px] overflow-y-auto px-0 py-4 lg:p-4">
+        <main className="flex-1 overflow-y-auto">
           {children}
         </main>
       </div>

--- a/bin/coordinator-frontend/src/app/dashboard/settings/components/General.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/settings/components/General.tsx
@@ -28,16 +28,16 @@ const General = () => {
   return (
     <div className="w-full h-full flex flex-col gap-4 ">
       {/* account signer list  */}
-      <div className="w-full h-full border-[0.5px] border-[#00000033] flex flex-col gap-2 p-4">
-        <div className="text-[16px] font-dmmono font-[500] text-[#00000099]">
-          ACCOUNT SIGNERS
+      <div className="w-full h-full border border-[rgba(0,0,0,0.08)] rounded-[10px] flex flex-col gap-2 p-4">
+        <div className="text-[16px] font-geist font-[500] text-[#00000099]">
+          Account signers
         </div>
         <div className="flex flex-col gap-4 ">
           {syncingState ? (
             <div className="flex items-center justify-center py-8">
               <div className="flex flex-col items-center gap-3">
                 <div className="animate-spin rounded-full h-8 w-8 border-2 border-[#00000033] border-t-[#FF5500]"></div>
-                <p className="text-[#00000099] font-dmmono text-sm font-[400]">
+                <p className="text-[#00000099] font-geist text-sm font-[400]">
                   Loading signers...
                 </p>
               </div>
@@ -46,7 +46,7 @@ const General = () => {
             signerCommitments.map((commitment, index) => (
               <div
                 key={index}
-                className="flex flex-row items-center gap-2 border-[0.5px] border-[#00000033] p-2"
+                className="flex flex-row items-center gap-2 border border-[rgba(0,0,0,0.08)] rounded-[8px] p-2"
               >
                 <div className="w-[24px] h-[24px] border relative">
                   <Image
@@ -58,11 +58,11 @@ const General = () => {
                 </div>
 
                 <div className="flex flex-col flex-1">
-                  <span className="uppercase text-[12px] font-dmmono font-[500] text-[#000000]">
-                    SIGNER {index + 1}
+                  <span className="text-[12px] font-geist font-[500] text-[#000000]">
+                    Signer {index + 1}
                   </span>
                   <div className="flex items-center gap-2">
-                    <span className="text-[8px] font-dmmono font-[400] text-[#000000]">
+                    <span className="text-[8px] font-geist font-[400] text-[#000000]">
                       {truncateHex(commitment, 20, 10)}
                     </span>
                     <button
@@ -90,7 +90,7 @@ const General = () => {
             ))
           ) : (
             <div className="flex items-center justify-center py-8">
-              <p className="text-[#00000099] font-dmmono text-sm font-[400]">
+              <p className="text-[#00000099] font-geist text-sm font-[400]">
                 No signers found
               </p>
             </div>
@@ -99,29 +99,29 @@ const General = () => {
       </div>
 
       {/* wallet information and network settings  */}
-      <div className="w-full h-[250px] flex bg-[#FBFCFD] flex-row border-[0.5px] border-[#00000033] relative">
+      <div className="w-full h-[250px] flex bg-[#FBFCFD] flex-row border border-[rgba(0,0,0,0.08)] rounded-[10px] relative">
         <div className="flex flex-col w-1/2 h-full justify-between py-8 items-center ">
-          <div className=" text-[16px] text-[#00000099] uppercase font-dmmono font-[500]">
+          <div className=" text-[16px] text-[#00000099] font-geist font-[500]">
             Wallet information
           </div>
 
           <div className="flex flex-col items-center">
-            <span className="text-[16px] font-dmmono font-[500] text-[#000000]">
+            <span className="text-[16px] font-geist font-[500] text-[#000000]">
               Wallet Name
             </span>
-            <span className="text-[14px] font-dmmono font-[500] text-[#000000]">
+            <span className="text-[14px] font-geist font-[500] text-[#000000]">
               {walletName}
             </span>
           </div>
 
           <div className="flex flex-col items-center">
-            <span className="text-[16px] font-dmmono font-[500] text-[#000000]">
+            <span className="text-[16px] font-geist font-[500] text-[#000000]">
               Account ID
             </span>
             <div className="relative">
               <div className="flex items-center gap-2">
                 <span
-                  className="text-[14px] font-dmmono font-[500] text-[#000000] cursor-help"
+                  className="text-[14px] font-geist font-[500] text-[#000000] cursor-help"
                   onMouseEnter={() => setShowTooltip(true)}
                   onMouseLeave={() => setShowTooltip(false)}
                 >
@@ -152,7 +152,7 @@ const General = () => {
               </div>
 
               {showTooltip && accountId && (
-                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-800 text-white text-xs font-dmmono rounded shadow-lg whitespace-nowrap z-50">
+                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-800 text-white text-xs font-geist rounded shadow-lg whitespace-nowrap z-50">
                   {accountId}
                   <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-800"></div>
                 </div>
@@ -165,15 +165,15 @@ const General = () => {
         <div className="absolute left-1/2 top-4 bottom-4 w-[0.5px] bg-[#00000033] transform -translate-x-1/2"></div>
 
         <div className="flex flex-col w-1/2 h-full gap-8 py-8 items-center ">
-          <div className=" text-[16px] text-[#00000099] uppercase font-dmmono font-[500]">
-            NETWORK SETTINGS
+          <div className=" text-[16px] text-[#00000099] font-geist font-[500]">
+            Network settings
           </div>
 
           <div className="flex flex-col items-center">
-            <span className="text-[16px] font-dmmono font-[500] text-[#000000]">
+            <span className="text-[16px] font-geist font-[500] text-[#000000]">
               Current Network
             </span>
-            <span className="text-[14px] font-dmmono font-[500] text-[#000000]">
+            <span className="text-[14px] font-geist font-[500] text-[#000000]">
               Miden Devnet
             </span>
           </div>

--- a/bin/coordinator-frontend/src/app/dashboard/settings/components/Notifications.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/settings/components/Notifications.tsx
@@ -4,8 +4,8 @@ const Notifications = () => {
   return (
     <div className="w-full h-full flex items-center justify-center">
       <div className="text-center">
-        <h2 className="text-4xl font-dmmono font-bold text-gray-800">
-          COMING SOON
+        <h2 className="text-4xl font-geist font-bold text-gray-800">
+          Coming soon
         </h2>
       </div>
     </div>

--- a/bin/coordinator-frontend/src/app/dashboard/settings/components/Security.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/settings/components/Security.tsx
@@ -28,45 +28,45 @@ const Security = () => {
       <div className="space-y-6">
         {/* Wallet Source Section */}
         <div className="border border-gray-200 rounded-lg p-6">
-          <h3 className="text-[16px] font-dmmono font-[500] mb-4">WALLET SOURCE</h3>
+          <h3 className="text-[16px] font-geist font-[500] mb-4">Wallet source</h3>
           <div className="flex gap-3 mb-4">
             <button
               onClick={() => setWalletSource('local')}
-              className={`px-4 py-2 font-dmmono text-[12px] border rounded ${
+              className={`px-4 py-2 font-geist text-[12px] border rounded ${
                 walletSource === 'local' ? 'bg-[#FF5500] text-white border-[#FF5500]' : 'border-gray-200 hover:border-[#FF5500]'
               }`}
             >
-              LOCAL KEYS
+              Local keys
             </button>
             <button
               onClick={() => {
                 if (paraSession.connected) setWalletSource('para');
                 else openParaModal();
               }}
-              className={`px-4 py-2 font-dmmono text-[12px] border rounded ${
+              className={`px-4 py-2 font-geist text-[12px] border rounded ${
                 walletSource === 'para' ? 'bg-[#FF5500] text-white border-[#FF5500]' : 'border-gray-200 hover:border-[#FF5500]'
               }`}
             >
-              PARA WALLET {paraSession.connected ? '(connected)' : ''}
+              Para wallet {paraSession.connected ? '(connected)' : ''}
             </button>
             <button
               onClick={() => {
                 if (midenWalletSession.connected) setWalletSource('miden-wallet');
                 else connectMidenWallet();
               }}
-              className={`px-4 py-2 font-dmmono text-[12px] border rounded ${
+              className={`px-4 py-2 font-geist text-[12px] border rounded ${
                 walletSource === 'miden-wallet' ? 'bg-[#FF5500] text-white border-[#FF5500]' : 'border-gray-200 hover:border-[#FF5500]'
               }`}
             >
-              MIDEN WALLET {midenWalletSession.connected ? '(connected)' : ''}
+              Miden wallet {midenWalletSession.connected ? '(connected)' : ''}
             </button>
           </div>
 
           {/* Active Commitment */}
           <div className="bg-gray-50 p-3 rounded">
-            <div className="text-[10px] font-dmmono text-gray-500 uppercase mb-1">Active Commitment ({activeScheme})</div>
+            <div className="text-[10px] font-geist text-gray-500 mb-1">Active Commitment ({activeScheme})</div>
             <div
-              className="text-[11px] font-dmmono cursor-pointer hover:bg-gray-100 p-1 rounded break-all"
+              className="text-[11px] font-geist cursor-pointer hover:bg-gray-100 p-1 rounded break-all"
               onClick={() => activeCommitment && handleCopy(activeCommitment)}
               title="Click to copy"
             >
@@ -78,9 +78,9 @@ const Security = () => {
           {midenWalletSession.connected && walletSource === 'miden-wallet' && (
             <button
               onClick={disconnectMidenWallet}
-              className="mt-3 px-4 py-2 font-dmmono text-[12px] border border-red-300 text-red-600 rounded hover:bg-red-50"
+              className="mt-3 px-4 py-2 font-geist text-[12px] border border-red-300 text-red-600 rounded hover:bg-red-50"
             >
-              DISCONNECT MIDEN WALLET
+              Disconnect Miden wallet
             </button>
           )}
         </div>
@@ -88,12 +88,12 @@ const Security = () => {
         {/* Local Signer Keys Section */}
         {signer && (
           <div className="border border-gray-200 rounded-lg p-6">
-            <h3 className="text-[16px] font-dmmono font-[500] mb-4">LOCAL SIGNER KEYS</h3>
+            <h3 className="text-[16px] font-geist font-[500] mb-4">Local signer keys</h3>
             <div className="space-y-3">
               <div className="bg-gray-50 p-3 rounded">
-                <div className="text-[10px] font-dmmono text-gray-500 uppercase mb-1">Falcon Commitment</div>
+                <div className="text-[10px] font-geist text-gray-500 mb-1">Falcon Commitment</div>
                 <div
-                  className="text-[11px] font-dmmono cursor-pointer hover:bg-gray-100 p-1 rounded break-all"
+                  className="text-[11px] font-geist cursor-pointer hover:bg-gray-100 p-1 rounded break-all"
                   onClick={() => handleCopy(signer.falcon.commitment)}
                   title="Click to copy"
                 >
@@ -101,9 +101,9 @@ const Security = () => {
                 </div>
               </div>
               <div className="bg-gray-50 p-3 rounded">
-                <div className="text-[10px] font-dmmono text-gray-500 uppercase mb-1">ECDSA Commitment</div>
+                <div className="text-[10px] font-geist text-gray-500 mb-1">ECDSA Commitment</div>
                 <div
-                  className="text-[11px] font-dmmono cursor-pointer hover:bg-gray-100 p-1 rounded break-all"
+                  className="text-[11px] font-geist cursor-pointer hover:bg-gray-100 p-1 rounded break-all"
                   onClick={() => handleCopy(signer.ecdsa.commitment)}
                   title="Click to copy"
                 >
@@ -116,15 +116,15 @@ const Security = () => {
 
         {/* PSM Connection */}
         <div className="border border-gray-200 rounded-lg p-6">
-          <h3 className="text-[16px] font-dmmono font-[500] mb-4">PSM CONNECTION</h3>
+          <h3 className="text-[16px] font-geist font-[500] mb-4">PSM connection</h3>
           <div className="flex items-center gap-2 mb-2">
             <span className={`w-2 h-2 rounded-full ${
               psmStatus === 'connected' ? 'bg-green-500' :
               psmStatus === 'connecting' ? 'bg-yellow-500 animate-pulse' : 'bg-red-500'
             }`} />
-            <span className="text-[12px] font-dmmono">{psmStatus}</span>
+            <span className="text-[12px] font-geist">{psmStatus}</span>
           </div>
-          <div className="text-[11px] font-dmmono text-gray-500 break-all">{psmUrl}</div>
+          <div className="text-[11px] font-geist text-gray-500 break-all">{psmUrl}</div>
         </div>
       </div>
     </div>

--- a/bin/coordinator-frontend/src/app/dashboard/settings/components/Signers.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/settings/components/Signers.tsx
@@ -4,8 +4,8 @@ const Signers = () => {
   return (
     <div className="w-full h-full flex items-center justify-center">
       <div className="text-center">
-        <h2 className="text-4xl font-dmmono font-bold text-gray-800">
-          COMING SOON
+        <h2 className="text-4xl font-geist font-bold text-gray-800">
+          Coming soon
         </h2>
       </div>
     </div>

--- a/bin/coordinator-frontend/src/app/dashboard/settings/components/Transactionguard.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/settings/components/Transactionguard.tsx
@@ -4,8 +4,8 @@ const Transactionguard = () => {
   return (
     <div className="w-full h-full flex items-center justify-center">
       <div className="text-center">
-        <h2 className="text-4xl font-dmmono font-bold text-gray-800">
-          COMING SOON
+        <h2 className="text-4xl font-geist font-bold text-gray-800">
+          Coming soon
         </h2>
       </div>
     </div>

--- a/bin/coordinator-frontend/src/app/dashboard/settings/page.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/settings/page.tsx
@@ -13,11 +13,11 @@ const Settings = () => {
   const [activeTab, setActiveTab] = useState("general");
 
   const tabs = [
-    { id: "general", label: "GENERAL" },
-    { id: "security", label: "SECURITY" },
-    { id: "signers", label: "SIGNERS" },
-    { id: "notifications", label: "NOTIFICATIONS" },
-    { id: "transactionguard", label: "TRANSACTION GUARD" },
+    { id: "general", label: "General" },
+    { id: "security", label: "Security" },
+    { id: "signers", label: "Signers" },
+    { id: "notifications", label: "Notifications" },
+    { id: "transactionguard", label: "Transaction Guard" },
   ];
 
   const renderTabContent = () => {
@@ -39,52 +39,47 @@ const Settings = () => {
 
   return (
     <>
-      <div className="flex flex-col w-full h-full space-y-4 p-6">
-        <div className="flex flex-col w-full">
-          <span className="uppercase text-[24px] font-dmmono font-[500] text-[#000000]">
-            SETTINGS
-          </span>
-          <span className="text-[16px] font-dmmono font-[500] text-[#0000007A]">
+      <div className="flex flex-col w-full p-4 font-geist">
+        <div className="mb-4">
+          <div className="text-[#111] text-[22px] md:text-[24px] font-[600] font-geist">
+            Settings
+          </div>
+          <div className="text-[13px] md:text-[14px] text-[rgba(0,0,0,0.5)] font-geist font-[400] mt-1">
             Configure multisig account preferences and security
-          </span>
+          </div>
         </div>
 
-        {/* tab menu */}
-        <div className="w-full h-[56px] grid grid-cols-5 border-[0.5px] border-[#00000033] uppercase relative overflow-hidden rounded-sm">
+        {/* tab menu — segmented control */}
+        <div className="w-full grid grid-cols-5 bg-[rgba(245,245,245,1)] rounded-[10px] p-1 relative overflow-hidden mb-4">
           {/* Animated background indicator */}
           <div
-            className="absolute top-0 left-0 h-[56px] bg-[#FF5500] rounded-sm shadow-sm transition-transform duration-300 ease-in-out"
+            className="absolute top-1 bottom-1 left-1 bg-white rounded-[8px] shadow-sm transition-transform duration-300 ease-in-out"
             style={{
-              width: `${100 / tabs.length}%`,
-              transform: `translateX(${tabs.findIndex((tab) => tab.id === activeTab) * 100
-                }%)`,
+              width: `calc(${100 / tabs.length}% - 8px)`,
+              transform: `translateX(calc(${tabs.findIndex((tab) => tab.id === activeTab) * 100}% + ${tabs.findIndex((tab) => tab.id === activeTab) * 8}px))`,
             }}
           />
 
-          {tabs.map((tab, index) => (
+          {tabs.map((tab) => (
             <div
               key={tab.id}
               onClick={() => {
                 setActiveTab(tab.id);
               }}
-              className={`flex items-center  h-[56px] justify-center cursor-pointer text-[16px] font-dmmono font-[500] transition-all duration-300 relative z-10 select-none ${activeTab === tab.id
-                  ? "text-white font-semibold"
-                  : "text-black hover:text-gray-700"
-                }`}
+              className={`flex items-center h-10 justify-center cursor-pointer text-[12px] md:text-[13px] font-geist font-[500] transition-colors duration-200 relative z-10 select-none ${
+                activeTab === tab.id
+                  ? "text-[#FF5500]"
+                  : "text-[rgba(0,0,0,0.55)] hover:text-[#111]"
+              }`}
             >
-              <span
-                className={`transition-colors duration-150 ${activeTab === tab.id ? "text-white" : "text-black"
-                  }`}
-              >
-                {tab.label}
-              </span>
+              {tab.label}
             </div>
           ))}
         </div>
 
         {/* tab content */}
-        <div className="w-full ">
-          <div key={activeTab} className=" transition-opacity duration-200">
+        <div className="w-full">
+          <div key={activeTab} className="transition-opacity duration-200">
             {renderTabContent()}
           </div>
         </div>

--- a/bin/coordinator-frontend/src/app/dashboard/transactions/page.tsx
+++ b/bin/coordinator-frontend/src/app/dashboard/transactions/page.tsx
@@ -23,79 +23,95 @@ const Transactions: React.FC = () => {
   }, [proposals]);
 
   return (
-    <div className="flex flex-col p-2 w-[calc(100vw-150px)] font-dmmono">
+    <div className="flex flex-col p-4 w-full font-geist">
       {/*Heading*/}
-      <div className="p-2">
-        <div className="text-[#000000] text-[24px] font-[500] font-dmmono">
-          TRANSACTION HISTORY
+      <div className="mb-4">
+        <div className="text-[#111] text-[22px] md:text-[24px] font-[600] font-geist">
+          Transaction History
         </div>
-        <div className="text-[16px] text-[#0000007A] font-dmmono font-[500]">
+        <div className="text-[13px] md:text-[14px] text-[rgba(0,0,0,0.5)] font-geist font-[400] mt-1">
           Complete record of your wallet history
         </div>
       </div>
       {/*Top Cards Div*/}
-      <div className="grid grid-cols-12 gap-10 p-2">
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-3 md:gap-6">
         {/*Total Transactions Div*/}
-        <div className="col-span-4 flex flex-col justify-between h-[135px] border-[0.5px] border-[#00000033] p-3">
-          <div className="flex items-left space-x-2 font-dmmono text-black">
-            <Image
-              src={media.totalTransactionsIcon}
-              alt="totalTransactionsIcon"
-              quality={100}
-            />
-            <div className="font-dmmono text-[16px] text-[#000000] font-[500]">
+        <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                <line x1="8" y1="6" x2="21" y2="6"/>
+                <line x1="8" y1="12" x2="21" y2="12"/>
+                <line x1="8" y1="18" x2="21" y2="18"/>
+                <line x1="3" y1="6" x2="3.01" y2="6"/>
+                <line x1="3" y1="12" x2="3.01" y2="12"/>
+                <line x1="3" y1="18" x2="3.01" y2="18"/>
+              </svg>
+            </div>
+            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
               Total Proposals
             </div>
           </div>
-          <div>
-            <div className=" text-[24px] font-[500] font-dmmono text-[#000000]">
+          <div className="flex flex-col gap-1 mt-auto">
+            <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
               {stats.total}
             </div>
-            <div className="text-sm text-gray-700">All Time</div>
+            <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+              All time
+            </div>
           </div>
         </div>
         {/*Pending Div*/}
-        <div className="col-span-4 flex flex-col justify-between h-[135px] border-[0.5px] border-[#00000033] p-3">
-          <div className="flex items-left space-x-2 font-dmmono text-black">
-            <Image
-              src={media.thisMonthIcon}
-              alt="thisMonthIcon"
-              quality={100}
-            />
-            <div className="font-dmmono text-[16px] text-[#000000] font-[500]">
+        <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                <circle cx="12" cy="12" r="9"/>
+                <polyline points="12 7 12 12 15 14"/>
+              </svg>
+            </div>
+            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
               Pending
             </div>
           </div>
-          <div>
-            <div className=" text-[24px] font-[500] font-dmmono text-[#000000]">
+          <div className="flex flex-col gap-1 mt-auto">
+            <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
               {stats.pending}
             </div>
-            <div className="text-sm text-gray-700">Awaiting signatures</div>
+            <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+              Awaiting signatures
+            </div>
           </div>
         </div>
-        {/*Success Rate Div*/}
-        <div className="col-span-4 flex flex-col justify-between h-[135px] border-[0.5px] border-[#00000033] p-3">
-          <div className="flex items-left space-x-2 font-dmmono text-black">
-            <Image src={media.assetValIcon} alt="assetValIcon" quality={100} />
-            <div className="font-dmmono text-[16px] text-[#000000] font-[500]">
+        {/*Execution Rate Div*/}
+        <div className="col-span-4 flex flex-col h-[140px] md:h-[160px] border border-[rgba(0,0,0,0.08)] rounded-[10px] p-4 md:p-5 gap-3">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-[8px] bg-[#FF5500]/10 flex items-center justify-center shrink-0">
+              <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[16px] h-[16px]">
+                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+              </svg>
+            </div>
+            <div className="font-geist text-[14px] md:text-[15px] text-[#111] font-[600]">
               Execution Rate
             </div>
           </div>
-          <div>
-            <div className=" text-[24px] font-[500] font-dmmono text-[#000000]">
+          <div className="flex flex-col gap-1 mt-auto">
+            <div className="text-[28px] md:text-[32px] font-[600] font-geist text-[#111] leading-none">
               {stats.successRate}%
             </div>
-            <div className="text-sm text-gray-700">{stats.executed}/{stats.total} Executed</div>
+            <div className="text-[11px] md:text-[12px] font-geist text-[rgba(0,0,0,0.45)]">
+              {stats.executed}/{stats.total} Executed
+            </div>
           </div>
         </div>
       </div>
 
       {/*Pending Actions Div*/}
-      <div className="p-2">
+      <div className="mt-4">
         <PendingActions threshold={threshold} fixedHeight={false} />
       </div>
       {/*Recent Transactions Div*/}
-      <div className="p-2">
+      <div className="mt-4">
         <RecentTransactions threshold={threshold} fixedHeight={false} />
       </div>
     </div>

--- a/bin/coordinator-frontend/src/app/layout.tsx
+++ b/bin/coordinator-frontend/src/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${dmMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${dmMono.variable} font-geist antialiased`}
       >
         <Providers>
           {children}

--- a/bin/coordinator-frontend/src/app/login/createNewAccount/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/createNewAccount/page.tsx
@@ -227,23 +227,40 @@ const CreateNewAccount = () => {
 
   return (
     <>
-      <div className="  w-[90%] sm:w-[70%] flex flex-col md:space-y-14 sm:space-y-12 space-y-10 lg:space-y-16 md:w-[60%] lg:w-[60%] xl:w-[45%] mx-auto h-screen py-4 md:py-6">
+      <div className="w-[90%] sm:w-[70%] flex flex-col space-y-6 sm:space-y-7 md:space-y-8 lg:space-y-10 md:w-[60%] lg:w-[60%] xl:w-[45%] mx-auto h-screen py-4 md:py-6">
         {/* stepper starts here */}
-        <div className="w-full flex flex-col  space-y-1">
-          <div className="flex flex-row justify-between w-full">
-            <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500] font-geist">
-              Create New Account
+        <div className="w-full flex flex-col">
+          <div className="w-full">
+            <div className="relative w-full">
+              {/* Background track */}
+              <div className="absolute top-1/2 left-[15px] right-[15px] h-[2px] bg-[rgba(0,0,0,0.08)] -translate-y-1/2 rounded-full"></div>
+              {/* Progress fill */}
+              <div
+                className="absolute top-1/2 left-[15px] h-[2px] bg-[#FF5500] -translate-y-1/2 rounded-full transition-all duration-500 ease-out"
+                style={{ width: `calc((100% - 30px) * ${(currentStep - 1) / 3})` }}
+              ></div>
+              {/* Chips */}
+              <div className="relative flex justify-between items-center">
+                {[1, 2, 3, 4].map((step) => {
+                  const isActive = step === currentStep;
+                  const isCompleted = step < currentStep;
+                  return (
+                    <div
+                      key={step}
+                      className={`flex items-center justify-center rounded-full font-geist font-[500] transition-all duration-300 lg:w-[30px] lg:h-[30px] md:w-[28px] md:h-[28px] w-[26px] h-[26px] lg:text-[12px] text-[11px] shrink-0 ${
+                        isActive
+                          ? 'bg-[#FF5500] text-white shadow-[0_0_0_4px_rgba(255,85,0,0.12)]'
+                          : isCompleted
+                          ? 'bg-[#FF5500] text-white'
+                          : 'bg-white border border-[rgba(0,0,0,0.12)] text-[rgba(0,0,0,0.4)]'
+                      }`}
+                    >
+                      {step}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
-
-            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-geist font-[500] text-[rgba(0,0,0,0.5)]">
-              Step {currentStep} of 4
-            </div>
-          </div>
-          <div className="lg:h-[6px] md:h-[5px] sm:h-[4px] h-[4px] w-full bg-[#E5E5E5] relative rounded-full">
-            <div
-              className="lg:h-[6px] md:h-[5px] sm:h-[4px] h-[4px] bg-[#FF5500] absolute top-0 left-0 transition-all duration-300 ease-in-out rounded-full"
-              style={{ width: `${currentStep * 25}%` }}
-            ></div>
           </div>
         </div>
         {/* stepper ends here */}
@@ -263,17 +280,26 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
+                className="w-full min-h-[500px] flex flex-col lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
-                <div className="w-full flex flex-col items-center">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
-                    <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
+                <div className="w-full flex flex-row items-center gap-3">
+                  <div className="lg:w-[56px] lg:h-[56px] md:w-[48px] md:h-[48px] sm:w-[44px] sm:h-[44px] w-[40px] h-[40px] bg-[#DFD8D3] rounded-[10px] flex items-center justify-center shrink-0">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="lg:w-[28px] lg:h-[28px] md:w-[24px] md:h-[24px] sm:w-[22px] sm:h-[22px] w-[20px] h-[20px]">
+                      <line x1="4" y1="6" x2="20" y2="6"/>
+                      <circle cx="9" cy="6" r="2" fill="#DFD8D3"/>
+                      <line x1="4" y1="12" x2="20" y2="12"/>
+                      <circle cx="15" cy="12" r="2" fill="#DFD8D3"/>
+                      <line x1="4" y1="18" x2="20" y2="18"/>
+                      <circle cx="9" cy="18" r="2" fill="#DFD8D3"/>
+                    </svg>
                   </div>
-                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
-                    Account Configuration
-                  </div>
-                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-1">
-                    Set account name and security settings
+                  <div className="flex flex-col">
+                    <div className="font-geist font-[600] text-[#111] lg:text-[20px] md:text-[19px] sm:text-[17px] text-[16px]">
+                      Account Configuration
+                    </div>
+                    <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-0.5">
+                      Set account name and security settings
+                    </div>
                   </div>
                 </div>
 
@@ -287,7 +313,7 @@ const CreateNewAccount = () => {
                     onChange={(e) =>
                       handleInputChange("walletName", e.target.value)
                     }
-                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
                   />
                 </div>
 
@@ -319,7 +345,7 @@ const CreateNewAccount = () => {
                         }))
                       }
                       placeholder="Enter number of signatures required"
-                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
                     />
                   </div>
 
@@ -350,7 +376,7 @@ const CreateNewAccount = () => {
                         }))
                       }
                       placeholder="Enter number of signers"
-                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
                     />
                   </div>
                 </div>
@@ -370,7 +396,7 @@ const CreateNewAccount = () => {
                     type="text"
                     value={formData.network}
                     disabled
-                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] px-3 h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] text-[rgba(0,0,0,0.48)] font-geist font-[400] text-[13px] cursor-not-allowed"
+                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] px-3 h-[40px] rounded-[6px] text-[rgba(0,0,0,0.48)] font-geist font-[400] text-[13px] cursor-not-allowed"
                   />
                 </div>
               </motion.div>
@@ -389,18 +415,24 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] h-[500px] flex flex-col p-6"
+                className="w-full min-h-[500px] flex flex-col lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
-                <div className="w-full flex flex-col items-center space-y-1">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
-                    <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
+                <div className="w-full flex flex-row items-center gap-3">
+                  <div className="lg:w-[56px] lg:h-[56px] md:w-[48px] md:h-[48px] sm:w-[44px] sm:h-[44px] w-[40px] h-[40px] bg-[#DFD8D3] rounded-[10px] flex items-center justify-center shrink-0">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="lg:w-[28px] lg:h-[28px] md:w-[24px] md:h-[24px] sm:w-[22px] sm:h-[22px] w-[20px] h-[20px]">
+                      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+                      <circle cx="9" cy="7" r="4"/>
+                      <path d="M22 21v-2a4 4 0 0 0-3-3.87"/>
+                      <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+                    </svg>
                   </div>
-                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
-                    Add Signers
-                  </div>
-                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
-                    Add signer commitments that will be authorized to sign
-                    transactions
+                  <div className="flex flex-col">
+                    <div className="font-geist font-[600] text-[#111] lg:text-[20px] md:text-[19px] sm:text-[17px] text-[16px]">
+                      Add Signers
+                    </div>
+                    <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-0.5">
+                      Add signer commitments that will be authorized to sign transactions
+                    </div>
                   </div>
                 </div>
 
@@ -421,7 +453,7 @@ const CreateNewAccount = () => {
                             <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
                               Signer 1 — {walletSourceLabel}
                             </div>
-                            <div className="bg-[rgba(245,245,245,1)] w-full min-h-[36px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 py-2 font-geist font-[500] text-[10px] text-[rgba(0,0,0,0.55)] break-all">
+                            <div className="bg-[rgba(245,245,245,1)] w-full lg:min-h-[56px] md:min-h-[52px] sm:min-h-[48px] min-h-[40px] flex items-center border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 py-2 font-geist font-[500] text-[10px] text-[rgba(0,0,0,0.55)] break-all">
                               {activeCommitment || 'Generating keys...'}
                             </div>
                           </>
@@ -533,44 +565,52 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
+                className="w-full min-h-[500px] flex flex-col lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
-                <div className="w-full flex flex-col items-center">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
-                    <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
-                  </div>
-                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
-                    Review Configuration
-                  </div>
-                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-1">
-                    Please review your account settings before deployment
+                <div className="w-full flex flex-col">
+                  <div className="w-full flex flex-row items-center gap-3">
+                    <div className="lg:w-[56px] lg:h-[56px] md:w-[48px] md:h-[48px] sm:w-[44px] sm:h-[44px] w-[40px] h-[40px] bg-[#DFD8D3] rounded-[10px] flex items-center justify-center shrink-0">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="lg:w-[28px] lg:h-[28px] md:w-[24px] md:h-[24px] sm:w-[22px] sm:h-[22px] w-[20px] h-[20px]">
+                        <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/>
+                        <rect x="9" y="3" width="6" height="4" rx="1"/>
+                        <polyline points="9 14 11 16 15 12"/>
+                      </svg>
+                    </div>
+                    <div className="flex flex-col">
+                      <div className="font-geist font-[600] text-[#111] lg:text-[20px] md:text-[19px] sm:text-[17px] text-[16px]">
+                        Review Configuration
+                      </div>
+                      <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-0.5">
+                        Please review your account settings before deployment
+                      </div>
+                    </div>
                   </div>
 
-                  <div className="w-full flex flex-row justify-between mt-4">
-                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                  <div className="w-full flex flex-row justify-between items-center lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] mt-4">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                       Account Name
                     </div>
-                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
+                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)]">
                       {formData.walletName || "Not specified"}
                     </div>
                   </div>
                   <div className="w-full h-[1px] bg-[rgba(217,217,217,1)] opacity-[40%]"></div>
 
-                  <div className="w-full flex flex-row justify-between mt-4">
-                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                  <div className="w-full flex flex-row justify-between items-center lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px]">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                       Network
                     </div>
-                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
+                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)]">
                       {formData.network}
                     </div>
                   </div>
                   <div className="w-full h-[1px] bg-[rgba(217,217,217,1)] opacity-[40%]"></div>
 
-                  <div className="w-full flex flex-row justify-between mt-4">
-                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                  <div className="w-full flex flex-row justify-between items-center lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px]">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                       Signature Policy
                     </div>
-                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
+                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)]">
                       {formData.signatureThreshold && formData.totalSigners
                         ? `${formData.signatureThreshold} of ${formData.totalSigners} signatures required`
                         : "Not specified"}
@@ -595,18 +635,16 @@ const CreateNewAccount = () => {
                             initial={{ opacity: 0, y: 10 }}
                             animate={{ opacity: 1, y: 0 }}
                             transition={{ duration: 0.2, delay: index * 0.05 }}
-                            className={`font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] p-2 rounded transition-colors ${
-                              index === 0 ? 'bg-[#FF5500]/5 border border-[#FF5500]/20' : 'bg-[rgba(245,245,245,1)] hover:bg-[rgba(235,235,235,1)]'
-                            }`}
+                            className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] p-3 rounded-[6px] bg-[rgba(245,245,245,1)] transition-colors"
                           >
                             <div>
                               {index === 0 ? (
-                                <span>Signer 1: <strong className="text-[#FF5500]">{walletSourceLabel}</strong></span>
+                                <span>Signer 1: <strong className="text-[#111] font-[600]">{walletSourceLabel}</strong></span>
                               ) : (
                                 <span>Signer {index + 1}</span>
                               )}
                             </div>
-                            <div className="text-[10px] opacity-75 break-all">
+                            <div className="text-[10px] opacity-75 break-all mt-1">
                               {formData.signerPublicKeys[index] ||
                                 "Not specified"}
                             </div>
@@ -615,7 +653,7 @@ const CreateNewAccount = () => {
                       )}
                     </div>
                   </div>
-                  <div className="w-full border-[1.09px] border-[rgba(217,217,217,1)] text-[12px] font-geist font-[400] bg-[rgba(245,245,245,1)] p-2 ">
+                  <div className="w-full text-[12px] font-geist font-[400] text-[rgba(0,0,0,0.55)] mt-4">
                     Important: Once deployed, these settings cannot be changed.
                     Please ensure all information is correct before proceeding.
                   </div>
@@ -636,40 +674,51 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
+                className="w-full min-h-[500px] flex flex-col lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
-                <div className="w-full flex flex-col items-center">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
-                    <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
-                  </div>
-                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
-                    Create Account
-                  </div>
-                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-1">
-                    Deploy your multi-signature account to the blockchain
-                  </div>
-                  <div className="w-full h-[123px] border-[0.5px] border-[rgba(46,161,80,1)] flex flex-col items-center justify-center bg-[rgba(238,253,243,1)] my-10">
-                    <div className="relative w-[48px] h-[48px] my-2">
-                      <Image
-                        src={Svg.tick}
-                        alt="tick"
-                        fill
-                        objectFit="contain"
-                      />
+                <div className="w-full flex flex-col">
+                  <div className="w-full flex flex-row items-center gap-3">
+                    <div className="lg:w-[56px] lg:h-[56px] md:w-[48px] md:h-[48px] sm:w-[44px] sm:h-[44px] w-[40px] h-[40px] bg-[#DFD8D3] rounded-[10px] flex items-center justify-center shrink-0">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="#FF5500" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="lg:w-[28px] lg:h-[28px] md:w-[24px] md:h-[24px] sm:w-[22px] sm:h-[22px] w-[20px] h-[20px]">
+                        <path d="M12 3l1.9 5.6 5.6 1.9-5.6 1.9L12 18l-1.9-5.6-5.6-1.9 5.6-1.9z"/>
+                        <path d="M19 14v3"/>
+                        <path d="M20.5 15.5h-3"/>
+                        <path d="M5 17v3"/>
+                        <path d="M6.5 18.5h-3"/>
+                      </svg>
                     </div>
-                    <div className="font-geist font-[500] text-[rgba(46,161,80,1)] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px]">
-                      Ready to Deploy
+                    <div className="flex flex-col">
+                      <div className="font-geist font-[600] text-[#111] lg:text-[20px] md:text-[19px] sm:text-[17px] text-[16px]">
+                        Create Account
+                      </div>
+                      <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-0.5">
+                        Deploy your multi-signature account to the blockchain
+                      </div>
+                    </div>
+                  </div>
+                  <div className="w-full flex flex-row items-center gap-3 bg-[rgba(46,161,80,0.07)] rounded-[10px] lg:p-5 md:p-4 sm:p-4 p-3 mt-6">
+                    <div className="lg:w-[48px] lg:h-[48px] md:w-[44px] md:h-[44px] sm:w-[40px] sm:h-[40px] w-[36px] h-[36px] bg-white rounded-[10px] flex items-center justify-center shrink-0">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="rgba(46,161,80,1)" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" className="lg:w-[24px] lg:h-[24px] md:w-[22px] md:h-[22px] sm:w-[20px] sm:h-[20px] w-[18px] h-[18px]">
+                        <polyline points="20 6 9 17 4 12"/>
+                      </svg>
+                    </div>
+                    <div className="flex flex-col">
+                      <div className="font-geist font-[600] text-[rgba(46,161,80,1)] lg:text-[16px] md:text-[15px] sm:text-[14px] text-[13px]">
+                        Ready to deploy
+                      </div>
+                      <div className="font-geist font-[400] text-[rgba(46,161,80,0.65)] lg:text-[13px] md:text-[12px] sm:text-[11px] text-[10px] mt-0.5">
+                        All configuration checks passed
+                      </div>
                     </div>
                   </div>
 
-                  <div className="w-full border-[1.09px] border-[rgba(217,217,217,1)] text-[12px] font-geist font-[400] mt-14  bg-[rgba(245,245,245,1)] p-2  ]">
-                    Important: Once deployed, these settings cannot be changed.
-                    Please ensure all information is correct before proceeding.
+                  <div className="w-full lg:text-[13px] text-[12px] font-geist font-[400] text-[rgba(0,0,0,0.55)] mt-4 leading-relaxed">
+                    Once deployed, these settings cannot be changed. Please ensure all information is correct before proceeding.
                   </div>
 
                   {/* Error Display */}
                   {creationError && (
-                    <div className="w-full border-[1.09px] border-red-500 text-[12px] font-geist font-[400] mt-4 bg-red-50 p-2 text-red-600">
+                    <div className="w-full text-[12px] font-geist font-[400] mt-4 text-red-600">
                       Error: {creationError}
                     </div>
                   )}
@@ -679,10 +728,10 @@ const CreateNewAccount = () => {
           </AnimatePresence>
 
           {/* button section starts here  */}
-          <div className="w-[90%] mx-auto  lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] flex flex-row justify-between">
+          <div className="w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[44px] flex flex-row gap-3">
             <button
               onClick={handlePrevious}
-              className="bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] w-[144px] h-full font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
+              className="flex-1 bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] h-full font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
             >
               Previous
             </button>
@@ -700,7 +749,7 @@ const CreateNewAccount = () => {
                     filledSignersCount < totalSignersNum ||
                     filledPublicKeysCount < totalSignersNum))
               }
-              className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] rounded-[8px] h-full font-[500] font-geist lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 bg-[rgba(255,85,0,1)] rounded-[8px] h-full font-[500] font-geist lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {currentStep === 4
                 ? isCreating

--- a/bin/coordinator-frontend/src/app/login/createNewAccount/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/createNewAccount/page.tsx
@@ -231,17 +231,17 @@ const CreateNewAccount = () => {
         {/* stepper starts here */}
         <div className="w-full flex flex-col  space-y-1">
           <div className="flex flex-row justify-between w-full">
-            <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500] font-dmmono uppercase">
-              CREATE NEW ACCOUNT
+            <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500] font-geist">
+              Create New Account
             </div>
 
-            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-dmmono font-[500]">
-              STEP {currentStep} OF 4
+            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-geist font-[500] text-[rgba(0,0,0,0.5)]">
+              Step {currentStep} of 4
             </div>
           </div>
-          <div className="lg:h-[8px] md:h-[7px] sm:h-[6px] h-[5px] w-full bg-[#D9D9D9] relative">
+          <div className="lg:h-[6px] md:h-[5px] sm:h-[4px] h-[4px] w-full bg-[#E5E5E5] relative rounded-full">
             <div
-              className="lg:h-[8px] md:h-[7px] sm:h-[6px] h-[5px] bg-[#FF5500] absolute top-0 left-0 transition-all duration-300 ease-in-out"
+              className="lg:h-[6px] md:h-[5px] sm:h-[4px] h-[4px] bg-[#FF5500] absolute top-0 left-0 transition-all duration-300 ease-in-out rounded-full"
               style={{ width: `${currentStep * 25}%` }}
             ></div>
           </div>
@@ -263,23 +263,23 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border-[0.5px] border-[rgba(0,0,0,0.2)] min-h-[500px]  flex flex-col p-8 lg:space-y-8  md:space-y-7 sm:space-y-6 space-y-5"
+                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
-                <div className="w-full  flex flex-col items-center">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] relative ">
+                <div className="w-full flex flex-col items-center">
+                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
                     <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
                   </div>
-                  <div className="uppercase font-dmmono font-[500] text-[#FF5500] lg:text-[24px] md:text-[22px] sm:text-[20px] text-[19px] ">
-                    ACCOUNT CONFIGURATION
+                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
+                    Account Configuration
                   </div>
-                  <div className="font-dmmono font-[400] text-[#000000] opacity-[40%] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-1">
                     Set account name and security settings
                   </div>
                 </div>
 
                 <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5 ">
-                  <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
-                    ACCOUNT NAME
+                  <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                    Account Name
                   </div>
                   <input
                     type="text"
@@ -287,14 +287,14 @@ const CreateNewAccount = () => {
                     onChange={(e) =>
                       handleInputChange("walletName", e.target.value)
                     }
-                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] px-3 font-dmmono font-[500] text-[12px]"
+                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
                   />
                 </div>
 
                 <div className="w-full flex flex-col md:flex-row lg:space-x-8 md:space-x-7 sm:space-y-6 space-y-5 md:space-y-0">
                   <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5">
-                    <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
-                      SIGNATURE THRESHOLD
+                    <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                      Signature Threshold
                     </div>
                     <input
                       type="text"
@@ -319,13 +319,13 @@ const CreateNewAccount = () => {
                         }))
                       }
                       placeholder="Enter number of signatures required"
-                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] px-3 font-dmmono font-[500] text-[12px]"
+                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
                     />
                   </div>
 
                   <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5">
-                    <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
-                      TOTAL SIGNERS
+                    <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                      Total Signers
                     </div>
                     <input
                       type="text"
@@ -350,27 +350,27 @@ const CreateNewAccount = () => {
                         }))
                       }
                       placeholder="Enter number of signers"
-                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] px-3 font-dmmono font-[500] text-[12px]"
+                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
                     />
                   </div>
                 </div>
 
                 {/* Validation Error Display */}
                 {thresholdError && (
-                  <div className="w-full text-red-600 font-dmmono text-[12px] mt-2">
+                  <div className="w-full text-red-600 font-geist text-[12px] mt-2">
                     {thresholdError}
                   </div>
                 )}
 
                 <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5">
-                  <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
-                    NETWORK
+                  <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                    Network
                   </div>
                   <input
                     type="text"
                     value={formData.network}
                     disabled
-                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] px-3 h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] text-[rgba(0,0,0,0.48)] font-dmmono font-[500] text-[12px] cursor-not-allowed"
+                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] px-3 h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] text-[rgba(0,0,0,0.48)] font-geist font-[400] text-[13px] cursor-not-allowed"
                   />
                 </div>
               </motion.div>
@@ -389,16 +389,16 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border-[0.5px] border-[rgba(0,0,0,0.2)] h-[500px] flex flex-col p-6"
+                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] h-[500px] flex flex-col p-6"
               >
-                <div className="w-full flex flex-col items-center lg:space-y-2  sm:space-y-4 space-y-3">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] relative">
+                <div className="w-full flex flex-col items-center space-y-1">
+                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
                     <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
                   </div>
-                  <div className="uppercase font-dmmono font-[500] text-[#rgba(0,0,0,1)] lg:text-[24px] md:text-[22px] sm:text-[20px] text-[19px] ">
-                    ADD SIGNERS
+                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
+                    Add Signers
                   </div>
-                  <div className="font-dmmono font-[400] text-[#000000]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] ">
+                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                     Add signer commitments that will be authorized to sign
                     transactions
                   </div>
@@ -418,16 +418,16 @@ const CreateNewAccount = () => {
                       >
                         {activeSignerIndex === 0 ? (
                           <>
-                            <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
+                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
                               Signer 1 — {walletSourceLabel}
                             </div>
-                            <div className="bg-[rgba(245,245,245,1)] w-full min-h-[36px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 py-2 font-dmmono font-[500] text-[10px] text-[rgba(0,0,0,0.55)] break-all">
+                            <div className="bg-[rgba(245,245,245,1)] w-full min-h-[36px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 py-2 font-geist font-[500] text-[10px] text-[rgba(0,0,0,0.55)] break-all">
                               {activeCommitment || 'Generating keys...'}
                             </div>
                           </>
                         ) : (
                           <>
-                            <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
+                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
                               Signer {activeSignerIndex + 1} Commitment
                             </div>
                             <div className="flex items-center gap-1">
@@ -443,7 +443,7 @@ const CreateNewAccount = () => {
                                   )
                                 }
                                 placeholder="0x..."
-                                className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 font-dmmono font-[500] text-[12px] focus:outline-none focus:ring-2 focus:ring-[#FF5500]/60"
+                                className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 font-geist font-[500] text-[12px] focus:outline-none focus:ring-2 focus:ring-[#FF5500]/60"
                               />
                               {formData.signerAddresses.length > 1 && (
                                 <button
@@ -492,7 +492,7 @@ const CreateNewAccount = () => {
                         aria-label={i === 0 ? "Go to signer 1 (You)" : `Go to signer ${i + 1}`}
                         title={i === 0 ? "Signer 1 (You)" : `Signer ${i + 1}`}
                       >
-                        <span className="font-dmmono font-[500] text-[8px] lg:text-[9px] md:text-[8px] sm:text-[8px]">
+                        <span className="font-geist font-[500] text-[8px] lg:text-[9px] md:text-[8px] sm:text-[8px]">
                           {i === 0 ? "\u2605" : i + 1}
                         </span>
                       </button>
@@ -504,14 +504,14 @@ const CreateNewAccount = () => {
                   <button
                     onClick={handleAddSignerAddress}
                     disabled={!canAddSigner}
-                    className="bg-[rgba(255,85,0,1)] flex items-center justify-center w-[90%] lg:h-[56px] md:h-[52px] sm:h-[48px] h-[44px] mx-auto font-dmmono font-[500] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px] text-[rgba(255,255,255,1)] disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="bg-[rgba(255,85,0,1)] flex items-center justify-center w-[90%] lg:h-[56px] md:h-[52px] sm:h-[48px] h-[44px] mx-auto rounded-[8px] font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {canAddSigner
-                      ? "ADD ANOTHER SIGNER"
-                      : "MAX SIGNERS REACHED"}
+                      ? "Add Another Signer"
+                      : "Max Signers Reached"}
                   </button>
 
-                  <div className="lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] w-[80%] mx-auto font-dmmono text-center leading-relaxed">
+                  <div className="lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] w-[80%] mx-auto font-geist text-center leading-relaxed">
                     Security Note: Each signer should verify their commitment is
                     correct. Incorrect commitments cannot be easily changed
                     after deployment.
@@ -533,44 +533,44 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border-[0.5px] border-[rgba(0,0,0,0.2)] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
+                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
                 <div className="w-full flex flex-col items-center">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] relative">
+                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
                     <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
                   </div>
-                  <div className="uppercase font-dmmono font-[500] text-[rgba(0,0,0,1)] lg:text-[24px] md:text-[22px] sm:text-[20px] text-[19px] ">
-                    REVIEW CONFIGURATION
+                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
+                    Review Configuration
                   </div>
-                  <div className="font-dmmono font-[400] text-[#000000]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-1">
                     Please review your account settings before deployment
                   </div>
 
                   <div className="w-full flex flex-row justify-between mt-4">
-                    <div className="font-dmmono font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                       Account Name
                     </div>
-                    <div className="font-dmmono font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
+                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
                       {formData.walletName || "Not specified"}
                     </div>
                   </div>
                   <div className="w-full h-[1px] bg-[rgba(217,217,217,1)] opacity-[40%]"></div>
 
                   <div className="w-full flex flex-row justify-between mt-4">
-                    <div className="font-dmmono font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                       Network
                     </div>
-                    <div className="font-dmmono font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
+                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
                       {formData.network}
                     </div>
                   </div>
                   <div className="w-full h-[1px] bg-[rgba(217,217,217,1)] opacity-[40%]"></div>
 
                   <div className="w-full flex flex-row justify-between mt-4">
-                    <div className="font-dmmono font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
                       Signature Policy
                     </div>
-                    <div className="font-dmmono font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
+                    <div className="font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] ">
                       {formData.signatureThreshold && formData.totalSigners
                         ? `${formData.signatureThreshold} of ${formData.totalSigners} signatures required`
                         : "Not specified"}
@@ -579,7 +579,7 @@ const CreateNewAccount = () => {
                   <div className="w-full h-[1px] bg-[rgba(217,217,217,1)] opacity-[40%]"></div>
 
                   <div className="w-full flex flex-col mt-4">
-                    <div className="font-dmmono font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mb-2">
+                    <div className="font-geist font-[500] text-[rgba(0,0,0,1)]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mb-2">
                       Authorized Signers
                     </div>
                     <div
@@ -595,7 +595,7 @@ const CreateNewAccount = () => {
                             initial={{ opacity: 0, y: 10 }}
                             animate={{ opacity: 1, y: 0 }}
                             transition={{ duration: 0.2, delay: index * 0.05 }}
-                            className={`font-dmmono font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] p-2 rounded transition-colors ${
+                            className={`font-geist font-[500] lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] text-[rgba(0,0,0,0.55)] p-2 rounded transition-colors ${
                               index === 0 ? 'bg-[#FF5500]/5 border border-[#FF5500]/20' : 'bg-[rgba(245,245,245,1)] hover:bg-[rgba(235,235,235,1)]'
                             }`}
                           >
@@ -615,7 +615,7 @@ const CreateNewAccount = () => {
                       )}
                     </div>
                   </div>
-                  <div className="w-full border-[1.09px] border-[rgba(217,217,217,1)] text-[12px] font-dmmono font-[400] bg-[rgba(245,245,245,1)] p-2 ">
+                  <div className="w-full border-[1.09px] border-[rgba(217,217,217,1)] text-[12px] font-geist font-[400] bg-[rgba(245,245,245,1)] p-2 ">
                     Important: Once deployed, these settings cannot be changed.
                     Please ensure all information is correct before proceeding.
                   </div>
@@ -636,16 +636,16 @@ const CreateNewAccount = () => {
                   x: animationDirection === "forward" ? -100 : 100,
                 }}
                 transition={{ duration: 0.3, ease: "easeInOut" }}
-                className="w-full border-[0.5px] border-[rgba(0,0,0,0.2)] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
+                className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] min-h-[500px] flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5"
               >
-                <div className="w-full flex flex-col items-center ">
-                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] relative">
+                <div className="w-full flex flex-col items-center">
+                  <div className="lg:w-[48px] lg:h-[48px] md:w-[40px] md:h-[40px] sm:w-[36px] sm:h-[36px] w-[32px] h-[32px] bg-[#F9F9F9] border-[0.5px] border-[rgba(0,0,0,0.2)] rounded-[8px] relative">
                     <Image fill objectFit="contain" src={Svg.logo} alt="logo" />
                   </div>
-                  <div className="uppercase font-dmmono font-[500] text-[rgba(0,0,0,1)] lg:text-[24px] md:text-[22px] sm:text-[20px] text-[19px] ">
-                    CREATE ACCOUNT
+                  <div className="font-geist font-[600] text-[#111] lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] mt-2">
+                    Create Account
                   </div>
-                  <div className="font-dmmono font-[400] text-[#000000]  lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px]">
+                  <div className="font-geist font-[400] text-[rgba(0,0,0,0.45)] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] mt-1">
                     Deploy your multi-signature account to the blockchain
                   </div>
                   <div className="w-full h-[123px] border-[0.5px] border-[rgba(46,161,80,1)] flex flex-col items-center justify-center bg-[rgba(238,253,243,1)] my-10">
@@ -657,19 +657,19 @@ const CreateNewAccount = () => {
                         objectFit="contain"
                       />
                     </div>
-                    <div className="font-dmmono font-[500] text-[rgba(46,161,80,1)] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px]">
+                    <div className="font-geist font-[500] text-[rgba(46,161,80,1)] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px]">
                       Ready to Deploy
                     </div>
                   </div>
 
-                  <div className="w-full border-[1.09px] border-[rgba(217,217,217,1)] text-[12px] font-dmmono font-[400] mt-14  bg-[rgba(245,245,245,1)] p-2  ]">
+                  <div className="w-full border-[1.09px] border-[rgba(217,217,217,1)] text-[12px] font-geist font-[400] mt-14  bg-[rgba(245,245,245,1)] p-2  ]">
                     Important: Once deployed, these settings cannot be changed.
                     Please ensure all information is correct before proceeding.
                   </div>
 
                   {/* Error Display */}
                   {creationError && (
-                    <div className="w-full border-[1.09px] border-red-500 text-[12px] font-dmmono font-[400] mt-4 bg-red-50 p-2 text-red-600">
+                    <div className="w-full border-[1.09px] border-red-500 text-[12px] font-geist font-[400] mt-4 bg-red-50 p-2 text-red-600">
                       Error: {creationError}
                     </div>
                   )}
@@ -682,9 +682,9 @@ const CreateNewAccount = () => {
           <div className="w-[90%] mx-auto  lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] flex flex-row justify-between">
             <button
               onClick={handlePrevious}
-              className="bg-[rgba(249,249,249,1)] border-[1.09px] border-[rgba(0,0,0,1)] w-[144px] uppercase h-full font-dmmono font-[400] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px] "
+              className="bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] w-[144px] h-full font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
             >
-              PREVIOUS
+              Previous
             </button>
             <button
               onClick={handleNext}
@@ -700,13 +700,13 @@ const CreateNewAccount = () => {
                     filledSignersCount < totalSignersNum ||
                     filledPublicKeysCount < totalSignersNum))
               }
-              className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] h-full font-[500] font-dmmono lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px] text-[rgba(255,255,255,1)] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] rounded-[8px] h-full font-[500] font-geist lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {currentStep === 4
                 ? isCreating
-                  ? "CREATING..."
-                  : "CREATE ACCOUNT"
-                : "NEXT"}
+                  ? "Creating..."
+                  : "Create Account"
+                : "Next"}
             </button>
           </div>
           {/* button section ends here  */}

--- a/bin/coordinator-frontend/src/app/login/createNewAccount/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/createNewAccount/page.tsx
@@ -247,7 +247,7 @@ const CreateNewAccount = () => {
                   return (
                     <div
                       key={step}
-                      className={`flex items-center justify-center rounded-full font-geist font-[500] transition-all duration-300 lg:w-[30px] lg:h-[30px] md:w-[28px] md:h-[28px] w-[26px] h-[26px] lg:text-[12px] text-[11px] shrink-0 ${
+                      className={`flex items-center justify-center rounded-full font-[500] transition-all duration-300 lg:w-[30px] lg:h-[30px] md:w-[28px] md:h-[28px] w-[26px] h-[26px] lg:text-[12px] text-[11px] shrink-0 ${
                         isActive
                           ? 'bg-[#FF5500] text-white shadow-[0_0_0_4px_rgba(255,85,0,0.12)]'
                           : isCompleted
@@ -304,7 +304,7 @@ const CreateNewAccount = () => {
                 </div>
 
                 <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5 ">
-                  <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                  <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                     Account Name
                   </div>
                   <input
@@ -313,13 +313,13 @@ const CreateNewAccount = () => {
                     onChange={(e) =>
                       handleInputChange("walletName", e.target.value)
                     }
-                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-[400] text-[13px]"
                   />
                 </div>
 
                 <div className="w-full flex flex-col md:flex-row lg:space-x-8 md:space-x-7 sm:space-y-6 space-y-5 md:space-y-0">
                   <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5">
-                    <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                    <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                       Signature Threshold
                     </div>
                     <input
@@ -345,12 +345,12 @@ const CreateNewAccount = () => {
                         }))
                       }
                       placeholder="Enter number of signatures required"
-                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-[400] text-[13px]"
                     />
                   </div>
 
                   <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5">
-                    <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                    <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                       Total Signers
                     </div>
                     <input
@@ -376,27 +376,27 @@ const CreateNewAccount = () => {
                         }))
                       }
                       placeholder="Enter number of signers"
-                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                      className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[40px] rounded-[6px] px-3 font-[400] text-[13px]"
                     />
                   </div>
                 </div>
 
                 {/* Validation Error Display */}
                 {thresholdError && (
-                  <div className="w-full text-red-600 font-geist text-[12px] mt-2">
+                  <div className="w-full text-red-600 text-[12px] mt-2">
                     {thresholdError}
                   </div>
                 )}
 
                 <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5">
-                  <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                  <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                     Network
                   </div>
                   <input
                     type="text"
                     value={formData.network}
                     disabled
-                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] px-3 h-[40px] rounded-[6px] text-[rgba(0,0,0,0.48)] font-geist font-[400] text-[13px] cursor-not-allowed"
+                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[56px] md:h-[52px] sm:h-[48px] px-3 h-[40px] rounded-[6px] text-[rgba(0,0,0,0.48)] font-[400] text-[13px] cursor-not-allowed"
                   />
                 </div>
               </motion.div>
@@ -450,16 +450,16 @@ const CreateNewAccount = () => {
                       >
                         {activeSignerIndex === 0 ? (
                           <>
-                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                               Signer 1 — {walletSourceLabel}
                             </div>
-                            <div className="bg-[rgba(245,245,245,1)] w-full lg:min-h-[56px] md:min-h-[52px] sm:min-h-[48px] min-h-[40px] flex items-center border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 py-2 font-geist font-[500] text-[10px] text-[rgba(0,0,0,0.55)] break-all">
+                            <div className="bg-[rgba(245,245,245,1)] w-full lg:min-h-[56px] md:min-h-[52px] sm:min-h-[48px] min-h-[40px] flex items-center border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 py-2 font-[500] text-[10px] text-[rgba(0,0,0,0.55)] break-all">
                               {activeCommitment || 'Generating keys...'}
                             </div>
                           </>
                         ) : (
                           <>
-                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                               Signer {activeSignerIndex + 1} Commitment
                             </div>
                             <div className="flex items-center gap-1">
@@ -475,7 +475,7 @@ const CreateNewAccount = () => {
                                   )
                                 }
                                 placeholder="0x..."
-                                className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 font-geist font-[500] text-[12px] focus:outline-none focus:ring-2 focus:ring-[#FF5500]/60"
+                                className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] rounded-md px-3 font-[500] text-[12px] focus:outline-none focus:ring-2 focus:ring-[#FF5500]/60"
                               />
                               {formData.signerAddresses.length > 1 && (
                                 <button
@@ -536,14 +536,14 @@ const CreateNewAccount = () => {
                   <button
                     onClick={handleAddSignerAddress}
                     disabled={!canAddSigner}
-                    className="bg-[rgba(255,85,0,1)] flex items-center justify-center w-[90%] lg:h-[56px] md:h-[52px] sm:h-[48px] h-[44px] mx-auto rounded-[8px] font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="bg-[rgba(255,85,0,1)] flex items-center justify-center w-[90%] lg:h-[56px] md:h-[52px] sm:h-[48px] h-[44px] mx-auto rounded-[8px] font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {canAddSigner
                       ? "Add Another Signer"
                       : "Max Signers Reached"}
                   </button>
 
-                  <div className="lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] w-[80%] mx-auto font-geist text-center leading-relaxed">
+                  <div className="lg:text-[12px] md:text-[11px] sm:text-[10px] text-[9.5px] w-[80%] mx-auto text-center leading-relaxed">
                     Security Note: Each signer should verify their commitment is
                     correct. Incorrect commitments cannot be easily changed
                     after deployment.
@@ -653,7 +653,7 @@ const CreateNewAccount = () => {
                       )}
                     </div>
                   </div>
-                  <div className="w-full text-[12px] font-geist font-[400] text-[rgba(0,0,0,0.55)] mt-4">
+                  <div className="w-full text-[12px] font-[400] text-[rgba(0,0,0,0.55)] mt-4">
                     Important: Once deployed, these settings cannot be changed.
                     Please ensure all information is correct before proceeding.
                   </div>
@@ -712,13 +712,13 @@ const CreateNewAccount = () => {
                     </div>
                   </div>
 
-                  <div className="w-full lg:text-[13px] text-[12px] font-geist font-[400] text-[rgba(0,0,0,0.55)] mt-4 leading-relaxed">
+                  <div className="w-full lg:text-[13px] text-[12px] font-[400] text-[rgba(0,0,0,0.55)] mt-4 leading-relaxed">
                     Once deployed, these settings cannot be changed. Please ensure all information is correct before proceeding.
                   </div>
 
                   {/* Error Display */}
                   {creationError && (
-                    <div className="w-full text-[12px] font-geist font-[400] mt-4 text-red-600">
+                    <div className="w-full text-[12px] font-[400] mt-4 text-red-600">
                       Error: {creationError}
                     </div>
                   )}
@@ -731,7 +731,7 @@ const CreateNewAccount = () => {
           <div className="w-full lg:h-[56px] md:h-[52px] sm:h-[48px] h-[44px] flex flex-row gap-3">
             <button
               onClick={handlePrevious}
-              className="flex-1 bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] h-full font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
+              className="flex-1 bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] h-full font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
             >
               Previous
             </button>
@@ -749,7 +749,7 @@ const CreateNewAccount = () => {
                     filledSignersCount < totalSignersNum ||
                     filledPublicKeysCount < totalSignersNum))
               }
-              className="flex-1 bg-[rgba(255,85,0,1)] rounded-[8px] h-full font-[500] font-geist lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 bg-[rgba(255,85,0,1)] rounded-[8px] h-full font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {currentStep === 4
                 ? isCreating

--- a/bin/coordinator-frontend/src/app/login/loadExistingAccount/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/loadExistingAccount/page.tsx
@@ -58,52 +58,58 @@ const LoadExistingWallet = () => {
 
     return (
         <>
-            <div className="  w-[90%] sm:w-[70%] flex flex-col md:space-y-14 sm:space-y-12 space-y-10 lg:space-y-16 md:w-[50%] lg:w-[40%] mx-auto h-screen py-4 md:py-6">
+            <div className="w-[90%] sm:w-[70%] flex flex-col md:space-y-14 sm:space-y-12 space-y-10 lg:space-y-16 md:w-[50%] lg:w-[40%] mx-auto h-screen py-4 md:py-6">
                 {/* header starts here */}
-                <div className="w-full flex flex-col  space-y-1">
+                <div className="w-full flex flex-col space-y-1">
                     <div className="flex flex-row justify-between w-full">
-                        <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500] font-dmmono uppercase">
-                            LOAD EXISTING ACCOUNT
+                        <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500] font-geist">
+                            Load Existing Account
                         </div>
                     </div>
                 </div>
                 {/* header ends here */}
 
-                <div className="w-full flex flex-col lg:space-y-6 md:space-y-5 sm:space-y-4 space-y-3 ">
-                    <div className="w-full border-[0.5px] border-[rgba(0,0,0,0.2)] h-auto  flex flex-col p-8 lg:space-y-8 md:space-y-7 sm:space-y-6 space-y-5">
-                        <div className="w-full flex flex-col lg:space-y-2 md:space-y-1.5 sm:space-y-1 space-y-0.5 ">
-                            <div className="lg:text-[24px] md:text-[22px] sm:text-[20px] text-[19px] font-dmmono font-[500]">
-                                ENTER ACCOUNT ID
-                            </div>
-                            <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-dmmono font-[500]">
-                                Paste the hex account ID of the multisig account you want to load
+                <div className="w-full flex flex-col lg:space-y-6 md:space-y-5 sm:space-y-4 space-y-3">
+                    <div className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] h-auto flex flex-col p-8 lg:space-y-6 md:space-y-5 sm:space-y-4 space-y-4">
+                        <div className="w-full flex flex-col gap-5">
+                            <div>
+                                <div className="lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] font-geist font-[600] text-[#111]">
+                                    Enter Account ID
+                                </div>
+                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-geist font-[400] text-[rgba(0,0,0,0.45)] mt-1">
+                                    Paste the hex account ID of the multisig account you want to load
+                                </div>
                             </div>
 
-                            <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
-                                ACCOUNT NAME
+                            <div className="flex flex-col lg:space-y-2 md:space-y-1.5 space-y-1">
+                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                                    Account Name
+                                </div>
+                                <input
+                                    type="text"
+                                    value={accountName}
+                                    onChange={(e) => setAccountName(e.target.value)}
+                                    placeholder="Enter account name"
+                                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                                />
                             </div>
-                            <input
-                                type="text"
-                                value={accountName}
-                                onChange={(e) => setAccountName(e.target.value)}
-                                placeholder="Enter account name"
-                                className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] px-3 font-dmmono font-[500] text-[12px]"
-                            />
 
-                            <div className="uppercase lg:text-[16px] md:text-[14px] sm:text-[13px] text-[12px] font-dmmono">
-                                ACCOUNT ID
+                            <div className="flex flex-col lg:space-y-2 md:space-y-1.5 space-y-1">
+                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                                    Account ID
+                                </div>
+                                <input
+                                    type="text"
+                                    value={accountId}
+                                    onChange={(e) => setAccountId(e.target.value)}
+                                    placeholder="0x..."
+                                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                                />
                             </div>
-                            <input
-                                type="text"
-                                value={accountId}
-                                onChange={(e) => setAccountId(e.target.value)}
-                                placeholder="0x..."
-                                className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border-[1.09px] border-[rgba(217,217,217,1)] px-3 font-dmmono font-[500] text-[12px]"
-                            />
 
                             {/* Error Display */}
                             {displayError && (
-                                <div className="w-full border-[1.09px] border-red-500 text-[12px] font-dmmono font-[400] mt-2 bg-red-50 p-2 text-red-600">
+                                <div className="w-full border border-red-300 text-[12px] font-geist font-[400] bg-red-50 rounded-[6px] p-3 text-red-600">
                                     {displayError}
                                 </div>
                             )}
@@ -111,19 +117,19 @@ const LoadExistingWallet = () => {
                     </div>
 
                     {/* button section starts here  */}
-                    <div className="w-[90%] mx-auto  lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] flex flex-row justify-between">
+                    <div className="w-[90%] mx-auto lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] flex flex-row justify-between">
                         <button
                             onClick={() => router.back()}
-                            className="bg-[rgba(249,249,249,1)] border-[1.09px] border-[rgba(0,0,0,1)] w-[144px] uppercase h-full font-dmmono font-[400] lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px] "
+                            className="bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] w-[144px] h-full font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
                         >
-                            BACK
+                            Back
                         </button>
                         <button
                             onClick={handleLoadWallet}
                             disabled={loadingAccount}
-                            className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] h-full font-[500] font-dmmono lg:text-[16px] md:text-[14px] sm:text-[12px] text-[11px] text-[rgba(255,255,255,1)] disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] rounded-[8px] h-full font-[500] font-geist lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
                         >
-                            {loadingAccount ? "LOADING..." : "LOAD ACCOUNT"}
+                            {loadingAccount ? "Loading..." : "Load Account"}
                         </button>
                     </div>
                     {/* button section ends here  */}

--- a/bin/coordinator-frontend/src/app/login/loadExistingAccount/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/loadExistingAccount/page.tsx
@@ -62,7 +62,7 @@ const LoadExistingWallet = () => {
                 {/* header starts here */}
                 <div className="w-full flex flex-col space-y-1">
                     <div className="flex flex-row justify-between w-full">
-                        <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500] font-geist">
+                        <div className="md:text-[18px] sm:text-[16px] text-[15px] lg:text-[20px] font-[500]">
                             Load Existing Account
                         </div>
                     </div>
@@ -73,16 +73,16 @@ const LoadExistingWallet = () => {
                     <div className="w-full border border-[rgba(0,0,0,0.12)] rounded-[10px] h-auto flex flex-col p-8 lg:space-y-6 md:space-y-5 sm:space-y-4 space-y-4">
                         <div className="w-full flex flex-col gap-5">
                             <div>
-                                <div className="lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] font-geist font-[600] text-[#111]">
+                                <div className="lg:text-[22px] md:text-[20px] sm:text-[19px] text-[18px] font-[600] text-[#111]">
                                     Enter Account ID
                                 </div>
-                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-geist font-[400] text-[rgba(0,0,0,0.45)] mt-1">
+                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] font-[400] text-[rgba(0,0,0,0.45)] mt-1">
                                     Paste the hex account ID of the multisig account you want to load
                                 </div>
                             </div>
 
                             <div className="flex flex-col lg:space-y-2 md:space-y-1.5 space-y-1">
-                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                                     Account Name
                                 </div>
                                 <input
@@ -90,12 +90,12 @@ const LoadExistingWallet = () => {
                                     value={accountName}
                                     onChange={(e) => setAccountName(e.target.value)}
                                     placeholder="Enter account name"
-                                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-[400] text-[13px]"
                                 />
                             </div>
 
                             <div className="flex flex-col lg:space-y-2 md:space-y-1.5 space-y-1">
-                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-geist font-[500] text-[#111]">
+                                <div className="lg:text-[14px] md:text-[13px] sm:text-[12px] text-[12px] font-[500] text-[#111]">
                                     Account ID
                                 </div>
                                 <input
@@ -103,13 +103,13 @@ const LoadExistingWallet = () => {
                                     value={accountId}
                                     onChange={(e) => setAccountId(e.target.value)}
                                     placeholder="0x..."
-                                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-geist font-[400] text-[13px]"
+                                    className="bg-[rgba(245,245,245,1)] w-full lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] border border-[rgba(217,217,217,1)] rounded-[6px] px-3 font-[400] text-[13px]"
                                 />
                             </div>
 
                             {/* Error Display */}
                             {displayError && (
-                                <div className="w-full border border-red-300 text-[12px] font-geist font-[400] bg-red-50 rounded-[6px] p-3 text-red-600">
+                                <div className="w-full border border-red-300 text-[12px] font-[400] bg-red-50 rounded-[6px] p-3 text-red-600">
                                     {displayError}
                                 </div>
                             )}
@@ -120,14 +120,14 @@ const LoadExistingWallet = () => {
                     <div className="w-[90%] mx-auto lg:h-[44px] md:h-[40px] sm:h-[36px] h-[32px] flex flex-row justify-between">
                         <button
                             onClick={() => router.back()}
-                            className="bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] w-[144px] h-full font-geist font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
+                            className="bg-white border border-[rgba(0,0,0,0.15)] rounded-[8px] w-[144px] h-full font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-[#111] hover:bg-[rgba(0,0,0,0.03)] transition-colors"
                         >
                             Back
                         </button>
                         <button
                             onClick={handleLoadWallet}
                             disabled={loadingAccount}
-                            className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] rounded-[8px] h-full font-[500] font-geist lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="bg-[rgba(255,85,0,1)] px-4 min-w-[144px] rounded-[8px] h-full font-[500] lg:text-[14px] md:text-[13px] sm:text-[12px] text-[11px] text-white disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             {loadingAccount ? "Loading..." : "Load Account"}
                         </button>

--- a/bin/coordinator-frontend/src/app/login/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/page.tsx
@@ -21,165 +21,139 @@ const Page = () => {
   }, [reset])
 
   return (
-    <div className="w-full h-screen ">
-      <div className="relative w-full md:w-[90%] lg:w-[70%] mx-auto h-full flex flex-col space-y-4 sm:space-y-6 md:space-y-12 py-2 sm:py-5 md:py-10">
+    <div className="w-full h-screen">
+      <div className="relative w-full md:w-[90%] lg:w-[70%] mx-auto h-full flex flex-col space-y-6 sm:space-y-8 md:space-y-12 py-4 sm:py-6 md:py-10">
         {/* Header Section */}
-        <div className="flex flex-col w-full items-center space-y-2">
+        <div className="flex flex-col w-full items-center space-y-1">
           <div>
             <div className="relative w-[38px] h-[38px]">
               <Image src={Svg.logo} alt="logo" fill objectFit="contain" />
             </div>
           </div>
-          <div className="uppercase text-[22px] md:text-[36px] px-4 font-[500] font-dmmono tracking-[-2%]">
-            MULTI-SIGNATURE ACCOUNT
+          <div className="text-[24px] md:text-[36px] px-4 font-[500] font-geist tracking-[-0.02em]">
+            Multi-Signature Account
           </div>
-          <div className="text-[12px] md:text-[16px] text-[rgba(255,85,0,1)] px-4 uppercase tracking-[-2%] font-dmmono">
-            SECURE, ENTERPRISE-GRADE MULTI-SIGNATURE ACCOUNT MANAGEMENT
+          <div className="text-[13px] md:text-[15px] text-[rgba(255,85,0,1)] px-4 tracking-[-0.02em] font-geist">
+            Secure, Enterprise-Grade Multi-Signature Account Management
           </div>
         </div>
 
         {/* Two Cards */}
         <div className="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-4 items-center   md:items-stretch md:justify-center w-full">
           {/* CREATE NEW ACCOUNT */}
-          <div className="md:w-1/2 w-[90%] lg:max-h-[460px] relative space-y-4 flex flex-col border-[rgba(0,0,0,0.19)] border-[1px] p-[20px] md:p-[24px]">
-            <div className="w-[30px] bg-[rgba(249,249,249,1)] h-[30px] flex items-center justify-center">
-              <div className="text-[rgba(255,85,0,1)] text-[18px] md:text-[22px]">
+          <div className="md:w-1/2 w-[90%] relative flex flex-col border border-[rgba(0,0,0,0.12)] rounded-[10px] p-[28px] md:p-[36px] gap-0">
+            <div className="w-[36px] h-[36px] rounded-[8px] bg-[rgba(255,85,0,0.08)] flex items-center justify-center mb-3">
+              <div className="text-[rgba(255,85,0,1)] text-[20px] font-[300]">
                 +
               </div>
             </div>
-            <div className="text-[20px] md:text-[24px] font-dmmono">
-              CREATE NEW ACCOUNT
+            <div className="text-[18px] md:text-[22px] font-geist font-[600] tracking-[-0.02em] text-[#111]">
+              Create New Account
             </div>
-            <div className="text-[10px] md:text-[12px] font-[400] text-[rgba(0,0,0,0.7)]">
+            <div className="text-[13px] md:text-[14px] font-[400] text-[#000] leading-relaxed mt-2 mb-6 bg-[#f9f9f9] px-3 py-1.5 rounded-[4px]">
               Create a new multisig account with a custom signature threshold
             </div>
-            <div className="text-[10px] md:text-[12px] text-[rgba(0,0,0,1)] font-[500]">
-              SETUP STEPS
-            </div>
 
-            <div className="flex flex-col space-y-4 flex-1">
-              {/* Steps */}
-              <div className="flex flex-row w-full items-center  space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    1
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+            <div className="flex flex-col gap-[14px] flex-1">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  1
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Choose account name and configure signature threshold (e.g., 2-of-3)
                 </div>
               </div>
 
-              <div className="flex flex-row w-full items-center  space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    2
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  2
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Add signer addresses
                 </div>
               </div>
 
-              <div className="flex flex-row w-full items-center space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    3
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  3
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Deploy multisig account smart contract on Miden network
                 </div>
               </div>
 
-              <div className="flex flex-row w-full items-center space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    4
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  4
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Share account address with other signers
                 </div>
               </div>
             </div>
 
-            <button onClick={() => router.push("/login/createNewAccount")} className="mt-auto h-[38px] w-full flex flex-row items-center justify-center border border-[rgba(0,0,0,0.2)] bg-[rgba(249,249,249,1)] cursor-pointer">
-              <div className="flex items-center justify-center w-[5%] h-full text-[14px] md:text-[16px]">
-                +
-              </div>
-              <div className="uppercase font-dmmono text-[rgba(255,85,0,1)] text-[14px] md:text-[16px] tracking-[-4%] font-[500]">
-                create account
+            <button onClick={() => router.push("/login/createNewAccount")} className="group mt-8 h-[44px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
+              <div className="text-[rgba(255,85,0,1)] group-hover:text-white text-[15px] font-[300] transition-colors">+</div>
+              <div className="font-geist text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
+                Create Account
               </div>
             </button>
           </div>
 
           {/* LOAD EXISTING ACCOUNT */}
-          <div className="md:w-1/2 w-[90%] lg:max-h-[460px] relative space-y-4 flex flex-col border-[rgba(0,0,0,0.19)] border-[1px] p-[20px] md:p-[24px]">
-            <div className="w-[30px] bg-[rgba(249,249,249,1)] h-[30px] flex items-center justify-center">
+          <div className="md:w-1/2 w-[90%] relative flex flex-col border border-[rgba(0,0,0,0.12)] rounded-[10px] p-[28px] md:p-[36px] gap-0">
+            <div className="w-[36px] h-[36px] rounded-[8px] bg-[rgba(255,85,0,0.08)] flex items-center justify-center mb-3">
               <div className="relative w-[18px] h-[18px]">
                 <Image src={Svg.upload} alt="upload" fill objectFit="contain" />
               </div>
             </div>
-            <div className="text-[20px] md:text-[24px] font-dmmono">
-              LOAD EXISTING ACCOUNT
+            <div className="text-[18px] md:text-[22px] font-geist font-[600] tracking-[-0.02em] text-[#111]">
+              Load Existing Account
             </div>
-            <div className="text-[10px] md:text-[12px] font-[400] text-[rgba(0,0,0,0.7)]">
-              Connect to an existing multi-signature account using the multisig account address
-            </div>
-            <div className="text-[10px] md:text-[12px] text-[rgba(0,0,0,1)] font-[500]">
-              SETUP STEPS
+            <div className="text-[13px] md:text-[14px] font-[400] text-[#000] leading-relaxed mt-2 mb-6 bg-[#f9f9f9] px-3 py-1.5 rounded-[4px]">
+              Load an existing multisig account by entering its address
             </div>
 
-            <div className="flex flex-col space-y-4 flex-1">
-              {/* Steps */}
-              <div className="flex flex-row w-full items-center space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    1
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+            <div className="flex flex-col gap-[14px] flex-1">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  1
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Enter existing multisig account address
                 </div>
               </div>
 
-              <div className="flex flex-row w-full items-center space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    2
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  2
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Connect your wallet
                 </div>
               </div>
 
-              <div className="flex flex-row w-full items-center space-x-2">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    3
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  3
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Verify you&apos;re authorized as a signer to sign transactions
                 </div>
               </div>
 
-              <div className="flex flex-row w-full items-center space-x-2 ">
-                <div className="flex items-center w-[10%]">
-                  <span className="rounded-full w-[18px] h-[18px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px]">
-                    4
-                  </span>
-                </div>
-                <div className="text-[10px] font-dmmono font-[400] tracking-[-2%]">
+              <div className="flex flex-row w-full items-start space-x-3">
+                <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
+                  4
+                </span>
+                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
                   Access account dashboard and transaction history
                 </div>
               </div>
             </div>
 
-            <button onClick={() => router.push("/login/loadExistingAccount")} className="mt-auto h-[38px] w-full flex flex-row items-center justify-center border border-[rgba(0,0,0,0.2)] bg-[rgba(249,249,249,1)] cursor-pointer">
-              <div className="relative w-[24px] h-[24px]">
+            <button onClick={() => router.push("/login/loadExistingAccount")} className="group mt-8 h-[44px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
+              <div className="relative w-[16px] h-[16px]">
                 <Image
                   src={Svg.upload_black}
                   alt="upload"
@@ -187,13 +161,13 @@ const Page = () => {
                   objectFit="contain"
                 />
               </div>
-              <div className="uppercase font-dmmono text-[rgba(255,85,0,1)] text-[14px] md:text-[16px] tracking-[-4%] font-[500]">
-                UPLOAD EXISTING ACCOUNT
+              <div className="font-geist text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
+                Load Existing Account
               </div>
             </button>
           </div>
         </div>
-        <div className="text-center text-[14px] md:text-[16px] uppercase font-[400] font-dmmono pb-[20px] md:pb-0">
+        <div className="text-center text-[13px] md:text-[14px] uppercase font-[400] font-geist text-[rgba(0,0,0,0.5)] pb-[20px] md:pb-0">
           POWERED BY INICIO LABS & MIDEN
         </div>
         {/* Footer */}
@@ -207,7 +181,7 @@ const Page = () => {
             <div className="relative w-[13px] h-[13px]">
               <Image src={Svg.logo} alt="logo" fill objectFit="contain" />
             </div>
-            <div className="font-dmmono text-[13px] md:text-[15px] font-[500] tracking-[-3%] uppercase">
+            <div className="font-geist text-[13px] md:text-[15px] font-[500] tracking-[-3%] uppercase">
               miden
             </div>
           </a>

--- a/bin/coordinator-frontend/src/app/login/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/page.tsx
@@ -30,10 +30,10 @@ const Page = () => {
               <Image src={Svg.logo} alt="logo" fill objectFit="contain" />
             </div>
           </div>
-          <div className="text-[24px] md:text-[36px] px-4 font-[500] font-geist tracking-[-0.02em]">
+          <div className="text-[24px] md:text-[36px] px-4 font-[500] tracking-[-0.02em]">
             Multi-Signature Account
           </div>
-          <div className="text-[13px] md:text-[15px] text-[rgba(255,85,0,1)] px-4 tracking-[-0.02em] font-geist">
+          <div className="text-[13px] md:text-[15px] text-[rgba(255,85,0,1)] px-4 tracking-[-0.02em]">
             Secure, Enterprise-Grade Multi-Signature Account Management
           </div>
         </div>
@@ -47,7 +47,7 @@ const Page = () => {
                 +
               </div>
             </div>
-            <div className="text-[18px] md:text-[22px] font-geist font-[600] tracking-[-0.02em] text-[#111]">
+            <div className="text-[18px] md:text-[22px] font-[600] tracking-[-0.02em] text-[#111]">
               Create New Account
             </div>
             <div className="text-[13px] md:text-[14px] font-[400] text-[#000] leading-relaxed mt-2 mb-6 bg-[#f9f9f9] px-3 py-1.5 rounded-[4px]">
@@ -59,7 +59,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   1
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Choose account name and configure signature threshold (e.g., 2-of-3)
                 </div>
               </div>
@@ -68,7 +68,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   2
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Add signer addresses
                 </div>
               </div>
@@ -77,7 +77,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   3
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Deploy multisig account smart contract on Miden network
                 </div>
               </div>
@@ -86,7 +86,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   4
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Share account address with other signers
                 </div>
               </div>
@@ -94,7 +94,7 @@ const Page = () => {
 
             <button onClick={() => router.push("/login/createNewAccount")} className="group mt-8 h-[56px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
               <div className="text-[rgba(255,85,0,1)] group-hover:text-white text-[15px] font-[300] transition-colors">+</div>
-              <div className="font-geist text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
+              <div className="text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
                 Create Account
               </div>
             </button>
@@ -107,7 +107,7 @@ const Page = () => {
                 <Image src={Svg.upload} alt="upload" fill objectFit="contain" />
               </div>
             </div>
-            <div className="text-[18px] md:text-[22px] font-geist font-[600] tracking-[-0.02em] text-[#111]">
+            <div className="text-[18px] md:text-[22px] font-[600] tracking-[-0.02em] text-[#111]">
               Load Existing Account
             </div>
             <div className="text-[13px] md:text-[14px] font-[400] text-[#000] leading-relaxed mt-2 mb-6 bg-[#f9f9f9] px-3 py-1.5 rounded-[4px]">
@@ -119,7 +119,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   1
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Enter existing multisig account address
                 </div>
               </div>
@@ -128,7 +128,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   2
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Connect your wallet
                 </div>
               </div>
@@ -137,7 +137,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   3
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Verify you&apos;re authorized as a signer to sign transactions
                 </div>
               </div>
@@ -146,7 +146,7 @@ const Page = () => {
                 <span className="shrink-0 mt-[2px] rounded-full w-[20px] h-[20px] bg-[rgba(255,85,0,1)] text-white flex items-center justify-center text-[10px] font-[500]">
                   4
                 </span>
-                <div className="text-[14px] font-geist font-[400] text-[#333] leading-[1.5]">
+                <div className="text-[14px] font-[400] text-[#333] leading-[1.5]">
                   Access account dashboard and transaction history
                 </div>
               </div>
@@ -161,13 +161,13 @@ const Page = () => {
                   objectFit="contain"
                 />
               </div>
-              <div className="font-geist text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
+              <div className="text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
                 Load Existing Account
               </div>
             </button>
           </div>
         </div>
-        <div className="text-center text-[13px] md:text-[14px] uppercase font-[400] font-geist text-[rgba(0,0,0,0.5)] pb-[20px] md:pb-0">
+        <div className="text-center text-[13px] md:text-[14px] uppercase font-[400] text-[rgba(0,0,0,0.5)] pb-[20px] md:pb-0">
           POWERED BY INICIO LABS & MIDEN
         </div>
         {/* Footer */}
@@ -181,7 +181,7 @@ const Page = () => {
             <div className="relative w-[13px] h-[13px]">
               <Image src={Svg.logo} alt="logo" fill objectFit="contain" />
             </div>
-            <div className="font-geist text-[13px] md:text-[15px] font-[500] tracking-[-3%] uppercase">
+            <div className="text-[13px] md:text-[15px] font-[500] tracking-[-3%] uppercase">
               miden
             </div>
           </a>

--- a/bin/coordinator-frontend/src/app/login/page.tsx
+++ b/bin/coordinator-frontend/src/app/login/page.tsx
@@ -92,7 +92,7 @@ const Page = () => {
               </div>
             </div>
 
-            <button onClick={() => router.push("/login/createNewAccount")} className="group mt-8 h-[44px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
+            <button onClick={() => router.push("/login/createNewAccount")} className="group mt-8 h-[56px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
               <div className="text-[rgba(255,85,0,1)] group-hover:text-white text-[15px] font-[300] transition-colors">+</div>
               <div className="font-geist text-[rgba(255,85,0,1)] group-hover:text-white text-[13px] md:text-[14px] font-[500] transition-colors">
                 Create Account
@@ -152,7 +152,7 @@ const Page = () => {
               </div>
             </div>
 
-            <button onClick={() => router.push("/login/loadExistingAccount")} className="group mt-8 h-[44px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
+            <button onClick={() => router.push("/login/loadExistingAccount")} className="group mt-8 h-[56px] w-full flex flex-row items-center justify-center gap-2 border border-[rgba(0,0,0,0.12)] rounded-[8px] bg-white hover:bg-[#FF5500] transition-colors cursor-pointer">
               <div className="relative w-[16px] h-[16px]">
                 <Image
                   src={Svg.upload_black}

--- a/bin/coordinator-frontend/tailwind.config.js
+++ b/bin/coordinator-frontend/tailwind.config.js
@@ -12,6 +12,9 @@ module.exports = {
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',
+        brand: '#FF5500',
+        ink: '#111',
+        'border-soft': 'rgba(0,0,0,0.08)',
       },
       fontFamily: {
         'dbmono': ['DB Mono', 'monospace'],

--- a/bin/coordinator-frontend/tailwind.config.js
+++ b/bin/coordinator-frontend/tailwind.config.js
@@ -15,7 +15,8 @@ module.exports = {
       },
       fontFamily: {
         'dbmono': ['DB Mono', 'monospace'],
-        'dmmono': ['var(--font-dm-mono)', 'monospace'],  // Add this line here
+        'dmmono': ['var(--font-dm-mono)', 'monospace'],
+        'geist': ['var(--font-geist-sans)', 'sans-serif'],
           },
       keyframes: {
         'fade-in': {


### PR DESCRIPTION
## Summary
- Swap font from DM Mono to Geist across login, create account, and load account flows
- Remove all-caps text in favor of title case for a cleaner, more professional look
- Add rounded corners to cards, inputs, and buttons
- Improve spacing, typography hierarchy, and hover states on CTA buttons

## Test plan
- [ ] Verify login page renders correctly with new font and layout
- [ ] Verify Create New Account flow (all 4 steps) reflects updated styles
- [ ] Verify Load Existing Account page reflects updated styles
- [ ] Check hover states on CTA buttons (orange background, white text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)